### PR TITLE
Adjustments after using main as the default branch.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ labels: "bug"
 
 - [ ] I have confirmed this bug exists on the latest version of pytask.
 
-- [ ] (optional) I have confirmed this bug exists on the master branch of pytask.
+- [ ] (optional) I have confirmed this bug exists on the `main` branch of pytask.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -11,7 +11,7 @@ labels: "documentation"
 
 Provide the location of the documentation, e.g. an URL of the documentation.
 
-**Note**: You can check the latest versions of the docs on `master`
+**Note**: You can check the latest versions of the docs on `main`
 [here](https://pytask.readthedocs.io/en/latest).
 
 #### Documentation problem

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -2,7 +2,7 @@ name: Continuous Integration Workflow
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
     - '*'

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://readthedocs.org/projects/pytask-dev/badge/?version=latest
     :target: https://pytask-dev.readthedocs.io/en/latest
 
-.. image:: https://codecov.io/gh/pytask-dev/pytask/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/pytask-dev/pytask/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytask-dev/pytask
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@
 .. image:: https://readthedocs.org/projects/pytask-dev/badge/?version=latest
     :target: https://pytask-dev.readthedocs.io/en/latest
 
+.. image:: https://github.com/pytask-dev/pytask/workflows/Continuous%20Integration%20Workflow/badge.svg?branch=main
+    :target: https://github.com/pytask-dev/pytask/actions?query=branch%3Amain
+
 .. image:: https://codecov.io/gh/pytask-dev/pytask/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytask-dev/pytask
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>
 
 - :gh:`2` provided multiple small changes.
 - :gh:`3` implements a class which holds the execution report of one task.
+- :gh:`4` makes adjustments after moving to ``main`` as the default branch.
 
 
 0.0.1 - 2020-06-29

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ pytask
 .. image:: https://readthedocs.org/projects/pytask-dev/badge/?version=latest
     :target: https://pytask-dev.readthedocs.io/en/latest
 
-.. image:: https://codecov.io/gh/pytask-dev/pytask/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/pytask-dev/pytask/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytask-dev/pytask
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg


### PR DESCRIPTION
#### Changes

``pytask`` adopts `main` as the new name for the default branch.