### PR TITLE
Two fixes for the execution related to pytask-latex.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,14 @@ chronological order. Releases follow `semantic versioning <https://semver.org/>`
 all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>`_.
 
 
+0.0.3 - 2020-07-19
+------------------
+
+- :gh:`7` makes pytask exit with code 1 if a task failed and the
+  ``skip_ancestor_failed`` decorator is only applied to descendant tasks not the task
+  itself.
+
+
 0.0.2 - 2020-07-17
 ------------------
 

--- a/src/pytask/dag.py
+++ b/src/pytask/dag.py
@@ -9,11 +9,15 @@ def sort_tasks_topologically(dag):
             yield node
 
 
-def task_and_descending_tasks(task_name, dag):
-    yield task_name
+def descending_tasks(task_name, dag):
     for descendant in nx.descendants(dag, task_name):
         if "task" in dag.nodes[descendant]:
             yield descendant
+
+
+def task_and_descending_tasks(task_name, dag):
+    yield task_name
+    yield from descending_tasks(task_name, dag)
 
 
 def node_and_neigbors(dag, node):

--- a/src/pytask/exceptions.py
+++ b/src/pytask/exceptions.py
@@ -18,5 +18,9 @@ class ResolvingDependenciesError(PytaskError):
     """Exception during resolving dependencies."""
 
 
+class ExecutionError(PytaskError):
+    """Exception during execution."""
+
+
 class TaskDuplicatedError(PytaskError):
     """Exception for duplicated task during collection."""

--- a/src/pytask/main.py
+++ b/src/pytask/main.py
@@ -6,6 +6,7 @@ import pytask
 from pytask.database import create_database
 from pytask.enums import ExitCode
 from pytask.exceptions import CollectionError
+from pytask.exceptions import ExecutionError
 from pytask.exceptions import ResolvingDependenciesError
 from pytask.pluginmanager import get_plugin_manager
 
@@ -63,8 +64,10 @@ def main(config_from_cli):
     except ResolvingDependenciesError:
         session.exit_code = ExitCode.RESOLVING_DEPENDENCIES_FAILED
 
-    except Exception as e:
+    except ExecutionError:
         session.exit_code = ExitCode.FAILED
+
+    except Exception as e:
         if config["pdb"]:
             pdb.post_mortem()
         else:

--- a/src/pytask/parametrize.py
+++ b/src/pytask/parametrize.py
@@ -164,7 +164,7 @@ def _generate_product_of_names_and_functions(
         )
 
         # Convert parametrized dependencies and products to decorator.
-        func = copy.deepcopy(_copy_func(obj))
+        func = _copy_func(obj)
         func.pytestmark = copy.deepcopy(obj.pytestmark)
 
         for marker_name in ["depends_on", "produces"]:
@@ -188,7 +188,7 @@ def _to_tuple(x):
 
 
 def _copy_func(f):
-    """Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)"""
+    """Based on https://stackoverflow.com/a/13503277/7523785."""
     g = types.FunctionType(
         f.__code__,
         f.__globals__,


### PR DESCRIPTION
#### Changes

- Errors during the execution will cause the exit code to be one.
- When a task previously failed, it also was decorated with the `skip_ancestor_failed` decorator. It should only be applied to descendants.