### PR TITLE
Make naming of task files more flexible.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,7 +6,13 @@ chronological order. Releases follow `semantic versioning <https://semver.org/>`
 all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>`_.
 
 
-0.0.6 - 2020-xx-xx
+0.0.7 - 2020-xx-xx
+------------------
+
+- :gh:`25` allows to customize the names of the task files.
+
+
+0.0.6 - 2020-09-12
 ------------------
 
 - :gh:`16` reduces the traceback generated from tasks, failure section in report, fix

--- a/docs/reference_guides/configuration.rst
+++ b/docs/reference_guides/configuration.rst
@@ -124,6 +124,19 @@ The options
         strict_markers = True
 
 
+.. confval:: task_files
+
+    Change the pattern which identify task files.
+
+    .. code-block:: ini
+
+        task_files = task_*.py  # default
+
+        task_files =
+            task_*.py
+            tasks_*.py
+
+
 .. confval:: trace
 
     If you want to enter the interactive debugger in the beginning of each task, use

--- a/docs/reference_guides/configuration.rst
+++ b/docs/reference_guides/configuration.rst
@@ -100,7 +100,7 @@ The options
 
     .. code-block:: console
 
-        pytask --pdb
+        pytask build --pdb
 
     or use a truthy configuration value.
 
@@ -115,7 +115,7 @@ The options
 
     .. code-block:: console
 
-        pytask --strict-markers
+        pytask build --strict-markers
 
     or set the option to a truthy value.
 
@@ -143,7 +143,7 @@ The options
 
     .. code-block:: console
 
-        pytask --trace
+        pytask build --trace
 
     or set this option to a truthy value.
 

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -91,7 +91,7 @@ def pytask_collect_file_protocol(session, path, reports):
 
 @hookimpl
 def pytask_collect_file(session, path, reports):
-    if path.name.startswith("task_") and path.suffix == ".py":
+    if any(path.match(pattern) for pattern in session.config["task_files"]):
         spec = importlib.util.spec_from_file_location(path.stem, str(path))
 
         if spec is None:

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -95,7 +95,6 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
     config_from_file["ignore"] = parse_value_or_multiline_option(
         config_from_file.get("ignore")
     )
-
     config["ignore"] = (
         to_list(
             get_first_non_none_value(
@@ -118,6 +117,15 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
     if config["debug_pytask"]:
         config["pm"].trace.root.setwriter(click.echo)
         config["pm"].enable_tracing()
+
+    config_from_file["task_files"] = parse_value_or_multiline_option(
+        config_from_file.get("task_files")
+    )
+    config["task_files"] = to_list(
+        get_first_non_none_value(
+            config_from_file, key="task_files", default="task_*.py"
+        )
+    )
 
 
 @hookimpl

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -88,8 +88,12 @@ def get_first_non_none_value(*configs, key, default=None, callback=None):
 
 
 def parse_value_or_multiline_option(value):
-    if isinstance(value, str) and "\n" in value:
+    if value in ["none", "None", None, ""]:
+        value = None
+    elif isinstance(value, str) and "\n" in value:
         value = [v.strip() for v in value.split("\n") if v.strip()]
+    elif isinstance(value, str) and "n" not in value:
+        value = value.strip()
     return value
 
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,5 +1,6 @@
 import pytest
 from _pytask.shared import convert_truthy_or_falsy_to_bool
+from _pytask.shared import parse_value_or_multiline_option
 
 
 @pytest.mark.unit
@@ -32,3 +33,20 @@ def test_convert_truthy_or_falsy_to_bool(value, expected):
 def test_raise_error_convert_truthy_or_falsy_to_bool(value, expectation):
     with expectation:
         convert_truthy_or_falsy_to_bool(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        ("None", None),
+        ("none", None),
+        ("first\nsecond", ["first", "second"]),
+        ("first", "first"),
+        ("", None),
+    ],
+)
+def test_parse_value_or_multiline_option(value, expected):
+    result = parse_value_or_multiline_option(value)
+    assert result == expected


### PR DESCRIPTION
#### Changes

It is possible to customize the files which pytask identifies as task files via the ``task_files`` configuration value.
