### PR TITLE
Commands return correct exit codes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-yaml
         exclude: meta.yaml
     -   id: debug-statements
-        exclude: (debugging\.py|build\.py)
+        exclude: (debugging\.py|build\.py|clean\.py|mark/__init__\.py)
     -   id: end-of-file-fixer
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>
 ------------------
 
 - :gh:`25` allows to customize the names of the task files.
+- :gh:`26` makes commands return the correct exit codes.
 - :gh:`27` implements the ``pytask_collect_task_teardown`` hook specification to perform
   checks after a task is collected.
 

--- a/src/_pytask/build.py
+++ b/src/_pytask/build.py
@@ -5,9 +5,9 @@ import traceback
 
 import click
 from _pytask.config import hookimpl
-from _pytask.database import create_database
 from _pytask.enums import ExitCode
 from _pytask.exceptions import CollectionError
+from _pytask.exceptions import ConfigurationError
 from _pytask.exceptions import ExecutionError
 from _pytask.exceptions import ResolvingDependenciesError
 from _pytask.pluginmanager import get_plugin_manager
@@ -49,12 +49,9 @@ def main(config_from_cli):
 
         config = pm.hook.pytask_configure(pm=pm, config_from_cli=config_from_cli)
 
-        create_database(**config["database"])
-
         session = Session.from_config(config)
-        session.exit_code = ExitCode.OK
 
-    except Exception:
+    except (ConfigurationError, Exception):
         traceback.print_exception(*sys.exc_info())
         session = Session({}, None)
         session.exit_code = ExitCode.CONFIGURATION_FAILED

--- a/src/_pytask/build.py
+++ b/src/_pytask/build.py
@@ -56,6 +56,9 @@ def main(config_from_cli):
         session = Session({}, None)
         session.exit_code = ExitCode.CONFIGURATION_FAILED
 
+        if config_from_cli.get("pdb"):
+            pdb.post_mortem()
+
     else:
         try:
             session.hook.pytask_log_session_header(session=session)

--- a/src/_pytask/clean.py
+++ b/src/_pytask/clean.py
@@ -71,9 +71,7 @@ def clean(**config_from_cli):
         pm.hook.pytask_add_hooks(pm=pm)
 
         config = pm.hook.pytask_configure(pm=pm, config_from_cli=config_from_cli)
-
         session = Session.from_config(config)
-        session.exit_code = ExitCode.OK
 
     except Exception:
         traceback.print_exception(*sys.exc_info())
@@ -119,7 +117,7 @@ def clean(**config_from_cli):
             traceback.print_exception(*sys.exc_info())
             session.exit_code = ExitCode.FAILED
 
-    return session
+    sys.exit(session.exit_code)
 
 
 def _collect_all_paths_known_to_pytask(session):

--- a/src/_pytask/clean.py
+++ b/src/_pytask/clean.py
@@ -1,5 +1,6 @@
 """Add a command to clean the project from files unknown to pytask."""
 import itertools
+import pdb
 import shutil
 import sys
 import traceback
@@ -77,6 +78,9 @@ def clean(**config_from_cli):
         traceback.print_exception(*sys.exc_info())
         session = Session({}, None)
         session.exit_code = ExitCode.CONFIGURATION_FAILED
+
+        if config_from_cli.get("pdb"):
+            pdb.post_mortem()
 
     else:
         try:

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -9,6 +9,7 @@ from typing import List
 
 import click
 import pluggy
+from _pytask.shared import convert_truthy_or_falsy_to_bool
 from _pytask.shared import get_first_non_none_value
 from _pytask.shared import parse_paths
 from _pytask.shared import parse_value_or_multiline_option
@@ -112,7 +113,7 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
         config_from_file,
         key="debug_pytask",
         default=False,
-        callback=bool,
+        callback=convert_truthy_or_falsy_to_bool,
     )
     if config["debug_pytask"]:
         config["pm"].trace.root.setwriter(click.echo)

--- a/src/_pytask/database.py
+++ b/src/_pytask/database.py
@@ -120,3 +120,8 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
         "create_db": config["database_create_db"],
         "create_tables": config["database_create_tables"],
     }
+
+
+@hookimpl
+def pytask_post_parse(config):
+    create_database(**config["database"])

--- a/src/_pytask/enums.py
+++ b/src/_pytask/enums.py
@@ -1,3 +1,4 @@
+"""Enumerations for pytask."""
 import enum
 
 

--- a/src/_pytask/exceptions.py
+++ b/src/_pytask/exceptions.py
@@ -10,6 +10,10 @@ class NodeNotCollectedError(PytaskError):
     """Exception for nodes which could not be collected."""
 
 
+class ConfigurationError(PytaskError):
+    """Exception during the configuration."""
+
+
 class CollectionError(PytaskError):
     """Exception during collection."""
 

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -1,3 +1,4 @@
+import pdb
 import sys
 import textwrap
 import traceback
@@ -51,6 +52,9 @@ def markers(**config_from_cli):
 
         config = pm.hook.pytask_configure(pm=pm, config_from_cli=config_from_cli)
         session = Session.from_config(config)
+
+        if config_from_cli.get("pdb"):
+            pdb.post_mortem()
 
     except Exception:
         traceback.print_exception(*sys.exc_info())

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -50,9 +50,7 @@ def markers(**config_from_cli):
         pm.hook.pytask_add_hooks(pm=pm)
 
         config = pm.hook.pytask_configure(pm=pm, config_from_cli=config_from_cli)
-
         session = Session.from_config(config)
-        session.exit_code = ExitCode.OK
 
     except Exception:
         traceback.print_exception(*sys.exc_info())
@@ -68,7 +66,7 @@ def markers(**config_from_cli):
             )
             click.echo("")
 
-    return session
+    sys.exit(session.exit_code)
 
 
 @hookimpl

--- a/src/_pytask/session.py
+++ b/src/_pytask/session.py
@@ -1,4 +1,5 @@
 import attr
+from _pytask.enums import ExitCode
 
 
 @attr.s
@@ -27,6 +28,7 @@ class Session:
     """
     execution_reports = attr.ib(factory=list)
     """Optional[List[pytask.report.ExecutionReport]]: Reports for executed tasks."""
+    exit_code = attr.ib(default=ExitCode.OK)
 
     @classmethod
     def from_config(cls, config):

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -1,3 +1,4 @@
+"""Functions which are used across various modules."""
 import glob
 from collections.abc import Iterable
 from pathlib import Path
@@ -71,13 +72,10 @@ def get_first_non_none_value(*configs, key, default=None, callback=None):
     --------
     >>> get_first_non_none_value({"a": None}, {"a": 1}, key="a")
     1
-
     >>> get_first_non_none_value({"a": None}, {"a": None}, key="a", default="default")
     'default'
-
     >>> get_first_non_none_value({}, {}, key="a", default="default")
     'default'
-
     >>> get_first_non_none_value({"a": None}, {"a": "b"}, key="a")
     'b'
 
@@ -88,6 +86,7 @@ def get_first_non_none_value(*configs, key, default=None, callback=None):
 
 
 def parse_value_or_multiline_option(value):
+    """Parse option which can hold a single value or values separated by new lines."""
     if value in ["none", "None", None, ""]:
         value = None
     elif isinstance(value, str) and "\n" in value:
@@ -107,6 +106,6 @@ def convert_truthy_or_falsy_to_bool(x):
         out = None
     else:
         raise ValueError(
-            f"Input {x} is neither truthy (True, true, 1) or falsy (False, false, 0)."
+            f"Input '{x}' is neither truthy (True, true, 1) or falsy (False, false, 0)."
         )
     return out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,54 @@
+import textwrap
+
+import pytest
+from pytask import cli
+
+
+@pytest.mark.end_to_end
+def test_execution_failed(runner, tmp_path):
+    source = """
+    def task_dummy():
+        raise Exception
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == 1
+
+
+@pytest.mark.end_to_end
+def test_configuration_failed(runner, tmp_path):
+    result = runner.invoke(cli, [tmp_path.joinpath("non_existent_path").as_posix()])
+    assert result.exit_code == 2
+
+
+@pytest.mark.end_to_end
+def test_collection_failed(runner, tmp_path):
+    source = """
+    raise Exception
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == 3
+
+
+@pytest.mark.end_to_end
+def test_resolving_dependencies_failed(runner, tmp_path):
+    source = """
+    import pytask
+
+    @pytask.mark.depends_on("in.txt")
+    @pytask.mark.produces("out.txt")
+    def task_dummy_1():
+        pass
+
+    @pytask.mark.depends_on("out.txt")
+    @pytask.mark.produces("in.txt")
+    def task_dummy_2():
+        pass
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == 4

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -107,3 +107,22 @@ def test_clean_interactive_w_directories(sample_project_path, runner):
     assert "to_be_deleted_file_2.txt" not in result.output
     assert "to_be_deleted_folder_1" in result.output
     assert not sample_project_path.joinpath("to_be_deleted_folder_1").exists()
+
+
+@pytest.mark.end_to_end
+def test_configuration_failed(runner, tmp_path):
+    result = runner.invoke(
+        cli, ["clean", tmp_path.joinpath("non_existent_path").as_posix()]
+    )
+    assert result.exit_code == 2
+
+
+@pytest.mark.end_to_end
+def test_collection_failed(runner, tmp_path):
+    source = """
+    raise Exception
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, ["clean", tmp_path.as_posix()])
+    assert result.exit_code == 3

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -272,3 +272,11 @@ def test_keyword_option_wrong_arguments(
 
     err = capsys.readouterr().err
     assert expected_error in err
+
+
+@pytest.mark.end_to_end
+def test_configuration_failed(runner, tmp_path):
+    result = runner.invoke(
+        cli, ["markers", "-c", tmp_path.joinpath("non_existent_path").as_posix()]
+    )
+    assert result.exit_code == 2


### PR DESCRIPTION
#### Changes

- The creation of the database is moved to the post-parse step in the configuration. Necessary for pytask-environment.
- Fix exit codes and test them.