### PR TITLE
Allow to pass dependencies and products as dictionaries.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,9 @@ all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>
 - :gh:`34` skips ``pytask_collect_task_teardown`` if task is None.
 - :gh:`35` adds the ability to capture stdout and stderr with the CaptureManager.
 - :gh:`36` reworks the debugger to make it work with the CaptureManager.
+- :gh:`37` cleans hooks related to collecting tasks.
+- :gh:`38` allows to pass dictionaries as dependencies and products and inside the
+  function ``depends_on`` and ``produces`` become dictionaries.
 
 
 0.0.8 - 2020-10-04

--- a/src/_pytask/clean.py
+++ b/src/_pytask/clean.py
@@ -55,7 +55,6 @@ def pytask_post_parse(config):
 
 @click.command()
 @click.option(
-    "-m",
     "--mode",
     type=click.Choice(["dry-run", "interactive", "force"]),
     help=_HELP_TEXT_MODE,

--- a/src/_pytask/clean.py
+++ b/src/_pytask/clean.py
@@ -165,7 +165,7 @@ def _yield_paths_from_task(task):
     """Yield all paths attached to a task."""
     yield task.path
     for attribute in ["depends_on", "produces"]:
-        for node in getattr(task, attribute):
+        for node in getattr(task, attribute).values():
             if isinstance(node.value, Path):
                 yield node.value
 

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -230,7 +230,7 @@ def pytask_collect_log(session, reports, tasks):
     failed_reports = [i for i in reports if not i.successful]
     if failed_reports:
         click.echo("")
-        click.echo(f"{{:=^{tm_width}}}".format(" Failures "))
+        click.echo(f"{{:=^{tm_width}}}".format(" Failures during collection "))
 
         for report in failed_reports:
             click.echo(f"{{:_^{tm_width}}}".format(report.format_title()))

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -3,6 +3,7 @@ import glob
 import importlib
 import inspect
 import sys
+import time
 import traceback
 from pathlib import Path
 
@@ -15,11 +16,14 @@ from _pytask.nodes import PythonFunctionTask
 from _pytask.report import CollectionReport
 from _pytask.report import CollectionReportFile
 from _pytask.report import CollectionReportTask
+from _pytask.report import format_collect_footer
 
 
 @hookimpl
 def pytask_collect(session):
     """Collect tasks."""
+    session.collection_start = time.time()
+
     reports = _collect_from_paths(session)
     tasks = _extract_successful_tasks_from_reports(reports)
 
@@ -31,13 +35,12 @@ def pytask_collect(session):
         )
         reports.append(report)
 
-    session.hook.pytask_collect_log(session=session, reports=reports, tasks=tasks)
-
     session.collection_reports = reports
     session.tasks = tasks
 
-    if any(i for i in reports if not i.successful):
-        raise CollectionError
+    session.hook.pytask_collect_log(
+        session=session, reports=session.collection_reports, tasks=session.tasks
+    )
 
     return True
 
@@ -214,19 +217,36 @@ def _extract_successful_tasks_from_reports(reports):
 @hookimpl
 def pytask_collect_log(session, reports, tasks):
     """Log collection."""
+    session.collection_end = time.time()
     tm_width = session.config["terminal_width"]
 
     message = f"Collected {len(tasks)} task(s)."
-    if session.deselected:
-        message += f" Deselected {len(session.deselected)} task(s)."
+
+    n_deselected = len(session.deselected)
+    if n_deselected:
+        message += f" Deselected {n_deselected} task(s)."
     click.echo(message)
 
     failed_reports = [i for i in reports if not i.successful]
     if failed_reports:
-        click.echo(f"{{:=^{tm_width}}}".format(" Errors during collection "))
+        click.echo("")
+        click.echo(f"{{:=^{tm_width}}}".format(" Failures "))
 
         for report in failed_reports:
             click.echo(f"{{:_^{tm_width}}}".format(report.format_title()))
-            traceback.print_exception(*report.exc_info)
+
             click.echo("")
-            click.echo("=" * tm_width)
+
+            traceback.print_exception(*report.exc_info)
+
+            click.echo("")
+
+            duration = round(session.collection_end - session.collection_start, 2)
+            click.echo(
+                format_collect_footer(
+                    len(tasks), len(failed_reports), n_deselected, duration, tm_width
+                ),
+                nl=True,
+            )
+
+        raise CollectionError

--- a/src/_pytask/collect_command.py
+++ b/src/_pytask/collect_command.py
@@ -85,8 +85,8 @@ def _organize_tasks(tasks):
 
         task_dict = {
             task_name: {
-                "depends_on": [node.name for node in task.depends_on],
-                "produces": [node.name for node in task.produces],
+                "depends_on": [node.name for node in task.depends_on.values()],
+                "produces": [node.name for node in task.produces.values()],
             }
         }
 

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -195,4 +195,5 @@ def _extract_nodes_from_function_markers(function, parser):
     """
     marker_name = parser.__name__
     for marker in get_marks_from_obj(function, marker_name):
-        yield from to_list(parser(*marker.args, **marker.kwargs))
+        parsed = parser(*marker.args, **marker.kwargs)
+        yield from to_list(parsed)

--- a/src/_pytask/parametrize.py
+++ b/src/_pytask/parametrize.py
@@ -13,6 +13,7 @@ from typing import Union
 
 from _pytask.config import hookimpl
 from _pytask.mark import MARK_GEN as mark  # noqa: N811
+from _pytask.shared import find_duplicates
 
 
 def parametrize(
@@ -110,7 +111,7 @@ def pytask_parametrize_task(session, name, obj):
             names_and_functions.append((name_, wrapped_func))
 
         names = [i[0] for i in names_and_functions]
-        duplicates = _find_duplicates(names)
+        duplicates = find_duplicates(names)
         if duplicates:
             formatted = pprint.pformat(
                 duplicates, width=session.config["terminal_width"]
@@ -355,25 +356,3 @@ def _copy_func(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
     new_func = functools.update_wrapper(new_func, func)
     new_func.__kwdefaults__ = func.__kwdefaults__
     return new_func
-
-
-def _find_duplicates(x: Iterable[Any]):
-    """Find duplicated entries in iterable.
-
-    Examples
-    --------
-    >>> _find_duplicates(["a", "b", "a"])
-    {'a'}
-    >>> _find_duplicates(["a", "b"])
-    set()
-
-    """
-    seen = set()
-    duplicates = set()
-
-    for i in x:
-        if i in seen:
-            duplicates.add(i)
-        seen.add(i)
-
-    return duplicates

--- a/src/_pytask/report.py
+++ b/src/_pytask/report.py
@@ -39,6 +39,7 @@ class CollectionReportTask:
 
     @classmethod
     def from_exception(cls, path, name, exc_info):
+        exc_info = remove_internal_traceback_frames_from_exc_info(exc_info)
         return cls(path=path, name=name, exc_info=exc_info)
 
     @property
@@ -107,6 +108,31 @@ def format_execute_footer(n_successful, n_failed, duration, terminal_width):
         )
     if n_failed:
         message.append(click.style(f"{n_failed} failed", fg=ColorCode.FAILED.value))
+    message = " " + ", ".join(message) + " "
+
+    color = ColorCode.FAILED.value if n_failed else ColorCode.SUCCESS.value
+    message += click.style(f"in {duration}s ", fg=color)
+
+    formatted_message = _wrap_string_ignoring_ansi_colors(
+        message, color, terminal_width
+    )
+
+    return formatted_message
+
+
+def format_collect_footer(
+    n_successful, n_failed, n_deselected, duration, terminal_width
+):
+    """Format the footer of the execution."""
+    message = []
+    if n_successful:
+        message.append(
+            click.style(f"{n_successful} collected", fg=ColorCode.SUCCESS.value)
+        )
+    if n_failed:
+        message.append(click.style(f"{n_failed} failed", fg=ColorCode.FAILED.value))
+    if n_deselected:
+        message.append(click.style(f"{n_deselected} deselected", fg="white"))
     message = " " + ", ".join(message) + " "
 
     color = ColorCode.FAILED.value if n_failed else ColorCode.SUCCESS.value

--- a/src/_pytask/report.py
+++ b/src/_pytask/report.py
@@ -77,6 +77,7 @@ class ResolvingDependenciesReport:
 
     @classmethod
     def from_exception(cls, exc_info):
+        exc_info = remove_internal_traceback_frames_from_exc_info(exc_info)
         return cls(exc_info)
 
 

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -57,11 +57,11 @@ def pytask_resolve_dependencies_create_dag(tasks):
     for task in tasks:
         dag.add_node(task.name, task=task)
 
-        for dependency in task.depends_on:
+        for dependency in task.depends_on.values():
             dag.add_node(dependency.name, node=dependency)
             dag.add_edge(dependency.name, task.name)
 
-        for product in task.produces:
+        for product in task.produces.values():
             dag.add_node(product.name, node=product)
             dag.add_edge(task.name, product.name)
 

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -90,6 +90,7 @@ def pytask_resolve_dependencies_validate_dag(dag):
     """Validate the DAG."""
     _check_if_dag_has_cycles(dag)
     _check_if_root_nodes_are_available(dag)
+    _check_if_tasks_have_the_same_products(dag)
 
 
 def _have_task_or_neighbors_changed(task_name, dag):
@@ -132,18 +133,42 @@ def _check_if_dag_has_cycles(dag):
 
 
 def _check_if_root_nodes_are_available(dag):
+    missing_root_nodes = {}
+
     for node in dag.nodes:
         is_node = "node" in dag.nodes[node]
         is_without_parents = len(list(dag.predecessors(node))) == 0
         if is_node and is_without_parents:
             try:
                 dag.nodes[node]["node"].state()
-            except NodeNotFoundError as e:
-                successors = list(dag.successors(node))
-                raise NodeNotFoundError(
-                    f"{node} is missing and a dependency of the following tasks: "
-                    f"{successors}."
-                ) from e
+            except NodeNotFoundError:
+                missing_root_nodes[node] = list(dag.successors(node))
+
+    if missing_root_nodes:
+        raise ResolvingDependenciesError(
+            "There are some dependencies missing which do not exist and are not "
+            "produced by any task. See the following dictionary with missing nodes as "
+            "keys and dependent tasks as values."
+            f"\n\n{pprint.pformat(missing_root_nodes)}"
+        )
+
+
+def _check_if_tasks_have_the_same_products(dag):
+    nodes_created_by_multiple_tasks = {}
+
+    for node in dag.nodes:
+        is_node = "node" in dag.nodes[node]
+        if is_node:
+            parents = list(dag.predecessors(node))
+            if len(parents) > 1:
+                nodes_created_by_multiple_tasks[node] = parents
+
+    if nodes_created_by_multiple_tasks:
+        raise ResolvingDependenciesError(
+            "There are some tasks which produce the same output. See the following "
+            "dictionary with products as keys and their producing tasks as values."
+            f"\n\n{pprint.pformat(nodes_created_by_multiple_tasks)}"
+        )
 
 
 @hookimpl
@@ -151,7 +176,9 @@ def pytask_resolve_dependencies_log(session, report):
     """Log errors which happened while resolving dependencies."""
     tm_width = session.config["terminal_width"]
 
-    click.echo(f"{{:=^{tm_width}}}".format(" Errors while resolving dependencies "))
+    click.echo(f"{{:=^{tm_width}}}".format(" Failures during resolving dependencies "))
+
+    click.echo("")
 
     traceback.print_exception(*remove_traceback_from_exc_info(report.exc_info))
 

--- a/src/_pytask/session.py
+++ b/src/_pytask/session.py
@@ -30,6 +30,11 @@ class Session:
     """Optional[List[pytask.report.ExecutionReport]]: Reports for executed tasks."""
     exit_code = attr.ib(default=ExitCode.OK)
 
+    collection_start = attr.ib(default=None)
+    collection_end = attr.ib(default=None)
+    execution_start = attr.ib(default=None)
+    execution_end = attr.ib(default=None)
+
     @classmethod
     def from_config(cls, config):
         """Construct the class from a config."""

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -2,6 +2,8 @@
 import glob
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
+from typing import Iterable
 
 
 def to_list(scalar_or_iter):
@@ -109,3 +111,25 @@ def convert_truthy_or_falsy_to_bool(x):
             f"Input '{x}' is neither truthy (True, true, 1) or falsy (False, false, 0)."
         )
     return out
+
+
+def find_duplicates(x: Iterable[Any]):
+    """Find duplicated entries in iterable.
+
+    Examples
+    --------
+    >>> find_duplicates(["a", "b", "a"])
+    {'a'}
+    >>> find_duplicates(["a", "b"])
+    set()
+
+    """
+    seen = set()
+    duplicates = set()
+
+    for i in x:
+        if i in seen:
+            duplicates.add(i)
+        seen.add(i)
+
+    return duplicates

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -1,6 +1,6 @@
 """Functions which are used across various modules."""
 import glob
-from collections.abc import Iterable
+from collections.abc import Sequence
 from pathlib import Path
 
 
@@ -25,7 +25,7 @@ def to_list(scalar_or_iter):
     """
     return (
         [scalar_or_iter]
-        if isinstance(scalar_or_iter, str) or not isinstance(scalar_or_iter, Iterable)
+        if isinstance(scalar_or_iter, str) or not isinstance(scalar_or_iter, Sequence)
         else list(scalar_or_iter)
     )
 

--- a/src/_pytask/traceback.py
+++ b/src/_pytask/traceback.py
@@ -17,13 +17,12 @@ def remove_internal_traceback_frames_from_exc_info(exc_info):
     """Remove internal traceback frames from exception info.
 
     If a non-internal traceback frame is found, return the traceback from the first
-    occurrence downwards. Otherwise, return the whole traceback.
+    occurrence downwards.
 
     """
     if exc_info is not None:
         filtered_traceback = _filter_internal_traceback_frames(exc_info[2])
-        if filtered_traceback is not None:
-            exc_info = (*exc_info[:2], filtered_traceback)
+        exc_info = (*exc_info[:2], filtered_traceback)
 
     return exc_info
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -84,7 +84,7 @@ def test_clean_dry_run_w_directories(sample_project_path, runner):
 @pytest.mark.end_to_end
 def test_clean_force(sample_project_path, runner):
     result = runner.invoke(
-        cli, ["clean", "-m", "force", sample_project_path.as_posix()]
+        cli, ["clean", "--mode", "force", sample_project_path.as_posix()]
     )
 
     assert "Remove" in result.output
@@ -99,7 +99,7 @@ def test_clean_force(sample_project_path, runner):
 @pytest.mark.end_to_end
 def test_clean_force_w_directories(sample_project_path, runner):
     result = runner.invoke(
-        cli, ["clean", "-d", "-m", "force", sample_project_path.as_posix()]
+        cli, ["clean", "-d", "--mode", "force", sample_project_path.as_posix()]
     )
 
     assert "Remove" in result.output
@@ -112,7 +112,7 @@ def test_clean_force_w_directories(sample_project_path, runner):
 def test_clean_interactive(sample_project_path, runner):
     result = runner.invoke(
         cli,
-        ["clean", "-m", "interactive", sample_project_path.as_posix()],
+        ["clean", "--mode", "interactive", sample_project_path.as_posix()],
         # Three instead of two because the compiled .pyc file is also present.
         input="y\ny\ny",
     )
@@ -130,7 +130,7 @@ def test_clean_interactive(sample_project_path, runner):
 def test_clean_interactive_w_directories(sample_project_path, runner):
     result = runner.invoke(
         cli,
-        ["clean", "-d", "-m", "interactive", sample_project_path.as_posix()],
+        ["clean", "-d", "--mode", "interactive", sample_project_path.as_posix()],
         # Three instead of two because the compiled .pyc file is also present.
         input="y\ny\ny",
     )

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -221,8 +221,8 @@ def test_organize_tasks():
     task = DummyClass()
     task.name = "prefix::task_dummy"
     task.path = "task_path.py"
-    task.depends_on = [dependency]
-    task.produces = []
+    task.depends_on = {0: dependency}
+    task.produces = {}
 
     result = _organize_tasks([task])
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import textwrap
 
@@ -8,17 +7,14 @@ from pytask import main
 
 @pytest.mark.end_to_end
 @pytest.mark.parametrize(
-    "dependencies, products",
-    itertools.product(
-        ([], ["in.txt"], ["in_1.txt", "in_2.txt"]),
-        (["out.txt"], ["out_1.txt", "out_2.txt"]),
-    ),
+    "dependencies",
+    [[], ["in.txt"], ["in_1.txt", "in_2.txt"]],
 )
+@pytest.mark.parametrize("products", [["out.txt"], ["out_1.txt", "out_2.txt"]])
 def test_execution_w_varying_dependencies_products(tmp_path, dependencies, products):
     source = f"""
     import pytask
     from pathlib import Path
-
 
     @pytask.mark.depends_on({dependencies})
     @pytask.mark.produces({products})
@@ -44,12 +40,10 @@ def test_depends_on_and_produces_can_be_used_in_task(tmp_path):
     import pytask
     from pathlib import Path
 
-
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
     def task_dummy(depends_on, produces):
         assert isinstance(depends_on, Path) and isinstance(produces, Path)
-
         produces.write_text(depends_on.read_text())
     """
     tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -23,12 +23,14 @@ def test_execution_w_varying_dependencies_products(tmp_path, dependencies, produ
     @pytask.mark.depends_on({dependencies})
     @pytask.mark.produces({products})
     def task_dummy(depends_on, produces):
-        if not isinstance(produces, list):
+        if isinstance(produces, dict):
+            produces = produces.values()
+        elif isinstance(produces, Path):
             produces = [produces]
         for product in produces:
             product.touch()
     """
-    tmp_path.joinpath("task_dummpy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
     for dependency in dependencies:
         tmp_path.joinpath(dependency).touch()
 

--- a/tests/test_resolve_dependencies.py
+++ b/tests/test_resolve_dependencies.py
@@ -14,8 +14,8 @@ from pytask import cli
 @attr.s
 class Task(MetaTask):
     name = attr.ib(type=str)
-    depends_on = attr.ib(default=[])
-    produces = attr.ib(default=[])
+    depends_on = attr.ib(factory=dict)
+    produces = attr.ib(factory=dict)
 
     def execute(self):
         pass
@@ -37,7 +37,10 @@ class Node(MetaNode):
 
 @pytest.mark.unit
 def test_create_dag():
-    task = Task(name="task", depends_on=[Node(name="node_1"), Node(name="node_2")])
+    task = Task(
+        name="task",
+        depends_on={0: Node(name="node_1"), 1: Node(name="node_2")},
+    )
 
     dag = pytask_resolve_dependencies_create_dag([task])
 

--- a/tests/test_resolve_dependencies.py
+++ b/tests/test_resolve_dependencies.py
@@ -1,9 +1,11 @@
 import textwrap
+from contextlib import ExitStack as does_not_raise  # noqa: N813
 
 import attr
 import networkx as nx
 import pytest
 from _pytask.exceptions import NodeNotFoundError
+from _pytask.exceptions import ResolvingDependenciesError
 from _pytask.nodes import MetaNode
 from _pytask.nodes import MetaTask
 from _pytask.resolve_dependencies import _check_if_root_nodes_are_available
@@ -58,22 +60,39 @@ def test_check_if_root_nodes_are_available():
     dag.add_node(available_node.name, node=available_node)
     dag.add_edge(available_node.name, task.name)
 
-    _check_if_root_nodes_are_available(dag)
+    with does_not_raise():
+        _check_if_root_nodes_are_available(dag)
 
     missing_node = Node("missing")
     dag.add_node(missing_node.name, node=missing_node)
     dag.add_edge(missing_node.name, task.name)
 
-    with pytest.raises(NodeNotFoundError):
+    with pytest.raises(ResolvingDependenciesError):
         _check_if_root_nodes_are_available(dag)
+
+
+@pytest.mark.end_to_end
+def test_check_if_root_nodes_are_available_end_to_end(tmp_path, runner):
+    source = """
+    import pytask
+
+    @pytask.mark.depends_on("in.txt")
+    @pytask.mark.produces("out.txt")
+    def task_dummy(produces):
+        produces.write_text("1")
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == 4
+    assert "Failures during resolving dependencies" in result.output
 
 
 @pytest.mark.end_to_end
 def test_cycle_in_dag(tmp_path, runner):
     source = """
     import pytask
-    from pathlib import Path
-
 
     @pytask.mark.depends_on("out_2.txt")
     @pytask.mark.produces("out_1.txt")
@@ -90,4 +109,25 @@ def test_cycle_in_dag(tmp_path, runner):
     result = runner.invoke(cli, [tmp_path.as_posix()])
 
     assert result.exit_code == 4
-    assert "Errors while resolving dependencies" in result.output
+    assert "Failures during resolving dependencies" in result.output
+
+
+@pytest.mark.end_to_end
+def test_two_tasks_have_the_same_product(tmp_path, runner):
+    source = """
+    import pytask
+
+    @pytask.mark.produces("out.txt")
+    def task_1(produces):
+        produces.write_text("1")
+
+    @pytask.mark.produces("out.txt")
+    def task_2(produces):
+        produces.write_text("2")
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == 4
+    assert "Failures during resolving dependencies" in result.output


### PR DESCRIPTION
- Remove ``-m`` flag for passing mode to ``pytask clean`` because it conflicts with marker expressions.
- Add check when tasks have the same product.
- Allow to pass dependencies and products as dictionaries.