### PR TITLE
Preserve inputs passed to depends_on and produces decorator.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,9 @@ all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask>
 - :gh:`39` releases v0.0.9.
 - :gh:`40` cleans up the capture manager and other parts of pytask.
 - :gh:`41` shortens the task ids in the error reports for better readability.
+- :gh:`42` ensures that lists with one element and dictionaries with only a zero key as
+  input for ``@pytask.mark.depends_on`` and ``@pytask.mark.produces`` are preserved as a
+  dictionary inside the function.
 
 
 0.0.8 - 2020-10-04


### PR DESCRIPTION
Whenever a list with a single element or a dictionary with only a 0-valued key is passed to one of the decorators, the dictionary is preserved and available inside the function instead of passing just the single value.