### PR TITLE
Add conda-forge to README and change wording in docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,10 @@ License
 
 pytask is distributed under the terms of the `MIT license <LICENSE>`_.
 
+
+Acknowledgment
+--------------
+
 The license also includes a copyright and permission notice from pytest since some
 modules, classes, and functions are copied from pytest. Not to mention how pytest has
 inspired the development pytask in general. Without the amazing work of Holger Krekel

--- a/README.rst
+++ b/README.rst
@@ -14,20 +14,21 @@
     :alt: PyPI - Python Version
     :target: https://pypi.org/project/pytask
 
-.. image:: https://anaconda.org/pytask/pytask/badges/version.svg
-    :target: https://anaconda.org/pytask/pytask
+.. image:: https://img.shields.io/conda/vn/conda-forge/pytask.svg
+    :target: https://anaconda.org/conda-forge/pytask
 
-.. image:: https://anaconda.org/pytask/pytask/badges/platforms.svg
-    :target: https://anaconda.org/pytask/pytask
+.. image:: https://img.shields.io/conda/pn/conda-forge/pytask.svg
+    :target: https://anaconda.org/conda-forge/pytask
 
 .. image:: https://img.shields.io/pypi/l/pytask
     :alt: PyPI - License
+    :target: https://pypi.org/project/pytask
 
 .. image:: https://readthedocs.org/projects/pytask-dev/badge/?version=latest
     :target: https://pytask-dev.readthedocs.io/en/latest
 
-.. image:: https://github.com/pytask-dev/pytask/workflows/Continuous%20Integration%20Workflow/badge.svg?branch=main
-    :target: https://github.com/pytask-dev/pytask/actions?query=branch%3Amain
+.. image:: https://img.shields.io/github/workflow/status/pytask-dev/pytask/Continuous%20Integration%20Workflow/main
+   :target: https://github.com/pytask-dev/pytask/actions?query=branch%3Amain
 
 .. image:: https://codecov.io/gh/pytask-dev/pytask/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytask-dev/pytask

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Installation
 .. start-installation
 
 pytask is available on `PyPI <https://pypi.org/project/pytask>`_ and on `Anaconda.org
-<https://anaconda.org/pytask/pytask>`_. Install the package with
+<https://anaconda.org/conda-forge/pytask>`_. Install the package with
 
 .. code-block:: console
 
@@ -99,8 +99,7 @@ pytask is available on `PyPI <https://pypi.org/project/pytask>`_ and on `Anacond
 
     # or
 
-    $ conda config --add channels conda-forge --add channels pytask
-    $ conda install pytask
+    $ conda install -c conda-forge pytask
 
 .. end-installation
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,7 +7,14 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 `Anaconda.org <https://anaconda.org/conda-forge/pytask>`_.
 
 
-0.0.12 - 2020-02-27
+0.0.13 - 2021-xx-xx
+-------------------
+
+- :gh:`72` adds conda-forge to the README and highlights importance of specifying
+  dependencies and products.
+
+
+0.0.12 - 2021-02-27
 -------------------
 
 - :gh:`55` implements miscellaneous fixes to improve error message, tests and coverage.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changes
 This is a record of all past pytask releases and what went into them in reverse
 chronological order. Releases follow `semantic versioning <https://semver.org/>`_ and
 all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
-`Anaconda.org <https://anaconda.org/pytask/pytask>`_.
+`Anaconda.org <https://anaconda.org/conda-forge/pytask>`_.
 
 
 0.0.12 - 2020-02-27

--- a/docs/tutorials/how_to_define_dependencies_products.rst
+++ b/docs/tutorials/how_to_define_dependencies_products.rst
@@ -4,6 +4,12 @@ How to define dependencies and products
 To make sure pytask executes all tasks in a correct order, we need to define which
 dependencies are required and which products are produced by a task.
 
+.. important::
+
+    If you do not specify all dependencies and products as explained below, pytask will
+    not able to build a graph, a :term:`DAG`, and will not be able to execute all tasks
+    in the project correctly!
+
 The information on dependencies and products can be attached to a task function with
 special markers. Let us have a look at some examples.
 
@@ -51,6 +57,11 @@ Most tasks have dependencies. Similar to products, you can use the
 
 Use ``depends_on`` as a function argument to work with the path of the dependency and,
 for example, load the data.
+
+.. important::
+
+    The two markers, ``pytask.mark.depends_on`` and ``pytask.mark.produces``, cannot be
+    used interchangeably!
 
 
 Conversion

--- a/docs/tutorials/how_to_define_dependencies_products.rst
+++ b/docs/tutorials/how_to_define_dependencies_products.rst
@@ -6,7 +6,7 @@ dependencies are required and which products are produced by a task.
 
 .. important::
 
-    If you do not specify all dependencies and products as explained below, pytask will
+    If you do not specify dependencies and products as explained below, pytask will
     not able to build a graph, a :term:`DAG`, and will not be able to execute all tasks
     in the project correctly!
 
@@ -61,7 +61,7 @@ for example, load the data.
 .. important::
 
     The two markers, ``pytask.mark.depends_on`` and ``pytask.mark.produces``, cannot be
-    used interchangeably!
+    used interchangeably! Use the first for dependencies and the latter for products.
 
 
 Conversion


### PR DESCRIPTION
- Add conda-forge to README
- Highlight importance of correctly specifying dependencies.