### PR TITLE
Raise error if paths are not correctly cased on case-insensitive Windows.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,9 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 -------------------
 
 - :gh:`80` replaces some remaining formatting using ``pprint`` with ``rich``.
+- :gh:`81` adds a warning if a path is not correctly cased on a case-insensitive file
+  system. This facilitates cross-platform builds of projects. Deactivate the check by
+  setting ``check_casing_of_paths = false`` in the configuration file.
 
 
 0.0.14 - 2021-03-23

--- a/docs/reference_guides/configuration.rst
+++ b/docs/reference_guides/configuration.rst
@@ -30,6 +30,22 @@ falsy.
 The options
 -----------
 
+.. confval:: check_casing_of_paths
+
+    Since pytask encourages platform-independent reproducibility, it will raise a
+    warning if you used a path with incorrect casing on a case-insensitive file system.
+    For example, the path ``TeXt.TxT`` will match the actual file ``text.txt`` on
+    case-insensitive file systems (usually Windows and macOS), but not on case-sensitive
+    systems (usually Linux).
+
+    If you have very strong reasons for relying on this inaccuracy, although, it is
+    strongly discouraged, you can deactivate the warning in the configuration file with
+
+    .. code-block:: ini
+
+        check_casing_of_paths = false
+
+
 .. confval:: ignore
 
     pytask can ignore files and directories and exclude some tasks or reduce the

--- a/docs/reference_guides/configuration.rst
+++ b/docs/reference_guides/configuration.rst
@@ -45,6 +45,11 @@ The options
 
         check_casing_of_paths = false
 
+    .. note::
+
+        An error is only raised on Windows when a case-insensitive path is used.
+        Contributions are welcome to also support macOS.
+
 
 .. confval:: ignore
 

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -153,7 +153,7 @@ _TEMPLATE_ERROR = (
     "The provided path of the dependency/product in the marker is {}, but the path of "
     "the file on disk is {}. Case-sensitive file systems would raise an error.\n\n"
     "Please, align the names to ensure reproducibility on case-sensitive file systems "
-    "(often Linux) or disable this error with 'check_casing_of_paths = false'."
+    "(often Linux or macOS) or disable this error with 'check_casing_of_paths = false'."
 )
 
 

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -190,8 +190,9 @@ def pytask_collect_node(session, path, node):
         if (
             not IS_FILE_SYSTEM_CASE_SENSITIVE
             and session.config["check_casing_of_paths"]
+            and sys.platform == "win32"
         ):
-            case_sensitive_path = find_case_sensitive_path(node, sys.platform)
+            case_sensitive_path = find_case_sensitive_path(node, "win32")
             if str(node) != str(case_sensitive_path):
                 raise Exception(_TEMPLATE_ERROR.format(node, case_sensitive_path))
 

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -2,6 +2,7 @@
 import configparser
 import itertools
 import os
+import tempfile
 import warnings
 from pathlib import Path
 from typing import List
@@ -16,12 +17,14 @@ from _pytask.shared import to_list
 
 hookimpl = pluggy.HookimplMarker("pytask")
 
+
 _IGNORED_FOLDERS = [
     ".git/*",
     ".hg/*",
     ".svn/*",
     ".venv/*",
 ]
+
 
 _IGNORED_FILES = [
     ".codecov.yml",
@@ -37,7 +40,9 @@ _IGNORED_FILES = [
     "tox.ini",
 ]
 
+
 _IGNORED_FILES_AND_FOLDERS = _IGNORED_FILES + _IGNORED_FOLDERS
+
 
 IGNORED_TEMPORARY_FILES_AND_FOLDERS = [
     "*.egg-info/*",
@@ -51,6 +56,15 @@ IGNORED_TEMPORARY_FILES_AND_FOLDERS = [
     "dist/*",
     "pytest_cache/*",
 ]
+
+
+def is_file_system_case_sensitive() -> bool:
+    """Check whether the file system is case-sensitive."""
+    with tempfile.NamedTemporaryFile(prefix="TmP") as tmp_file:
+        return not os.path.exists(tmp_file.name.lower())
+
+
+IS_FILE_SYSTEM_CASE_SENSITIVE = is_file_system_case_sensitive()
 
 
 @hookimpl

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -167,6 +167,14 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
             callback=lambda x: x if x is None else int(x),
         )
 
+    config["check_casing_of_paths"] = get_first_non_none_value(
+        config_from_cli,
+        config_from_file,
+        key="check_casing_of_paths",
+        default=True,
+        callback=convert_truthy_or_falsy_to_bool,
+    )
+
 
 @hookimpl
 def pytask_post_parse(config):

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -174,7 +174,8 @@ class FilePathNode(MetaNode):
         The `lru_cache` decorator ensures that the same object is not collected twice.
 
         """
-        path = path.resolve()
+        if not path.is_absolute():
+            raise ValueError("FilePathNode must be instantiated from absolute path.")
         return cls(path.as_posix(), path, path)
 
     def state(self):

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -186,8 +186,33 @@ class FilePathNode(MetaNode):
             return str(self.path.stat().st_mtime)
 
 
-def _collect_nodes(session, path, name, nodes):
-    """Collect nodes for a task."""
+def _collect_nodes(
+    session, path: Path, name: str, nodes: Dict[str, Union[str, Path]]
+) -> Dict[str, Path]:
+    """Collect nodes for a task.
+
+    Parameters
+    ----------
+    session : _pytask.session.Session
+        The session.
+    path : Path
+        The path to the task whose nodes are collected.
+    name : str
+        The name of the task.
+    nodes : Dict[str, Union[str, Path]]
+        A dictionary of nodes parsed from the ``depends_on`` or ``produces`` markers.
+
+    Returns
+    -------
+    Dict[str, Path]
+        A dictionary of node names and their paths.
+
+    Raises
+    ------
+    NodeNotCollectedError
+        If the node could not collected.
+
+    """
     collected_nodes = {}
 
     for node_name, node in nodes.items():

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -113,7 +113,7 @@ class PythonFunctionTask(MetaTask):
 
         return cls(
             base_name=name,
-            name=_create_task_name(path, name),
+            name=create_task_name(path, name),
             path=path,
             function=function,
             depends_on=dependencies,
@@ -353,13 +353,13 @@ def _convert_nodes_to_dictionary(
     return nodes
 
 
-def _create_task_name(path: Path, base_name: str):
+def create_task_name(path: Path, base_name: str):
     """Create the name of a task from a path and the task's base name.
 
     Examples
     --------
     >>> from pathlib import Path
-    >>> _create_task_name(Path("module.py"), "task_dummy")
+    >>> create_task_name(Path("module.py"), "task_dummy")
     'module.py::task_dummy'
 
     """
@@ -385,7 +385,7 @@ def reduce_node_name(node, paths: List[Path]):
 
     if isinstance(node, MetaTask):
         shortened_path = relative_to(node.path, ancestor)
-        name = _create_task_name(shortened_path, node.base_name)
+        name = create_task_name(shortened_path, node.base_name)
     elif isinstance(node, MetaNode):
         name = relative_to(node.path, ancestor).as_posix()
     else:

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 import networkx as nx
 from _pytask.config import hookimpl
+from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.console import ARROW_DOWN_ICON
 from _pytask.console import console
 from _pytask.console import FILE_ICON
@@ -156,6 +157,14 @@ def _format_cycles(cycles: List[Tuple[str]]) -> str:
     return text
 
 
+_TEMPLATE_ERROR = (
+    "Some dependencies do not exist or are not produced by any task. See the following "
+    "tree which shows which dependencies are missing for which tasks.\n\n{}"
+)
+if IS_FILE_SYSTEM_CASE_SENSITIVE:
+    _TEMPLATE_ERROR += "\n\n(Hint: Sometimes case sensitivity is at fault.)"
+
+
 def _check_if_root_nodes_are_available(dag):
     missing_root_nodes = []
 
@@ -187,11 +196,7 @@ def _check_if_root_nodes_are_available(dag):
             dictionary[short_node_name] = short_successors
 
         text = _format_dictionary_to_tree(dictionary, "Missing dependencies:")
-        raise ResolvingDependenciesError(
-            "Some dependencies do not exist or are not produced by any task. See the "
-            "following tree which shows which dependencies are missing for which tasks."
-            f"\n\n{text}"
-        )
+        raise ResolvingDependenciesError(_TEMPLATE_ERROR.format(text))
 
 
 def _format_dictionary_to_tree(dict_: Dict[str, List[str]], title: str) -> str:

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from _pytask.collect import pytask_collect_node
+from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.exceptions import NodeNotCollectedError
 from _pytask.session import Session
 from pytask import main
@@ -139,6 +140,9 @@ def test_pytask_collect_node(session, path, node, expectation, expected):
 
 
 @pytest.mark.unit
+@pytest.mark.skipif(
+    IS_FILE_SYSTEM_CASE_SENSITIVE, reason="Only works on case-insensitive file systems."
+)
 def test_pytask_collect_node_raises_error_if_path_is_not_correctly_cased(tmp_path):
     session = Session({"check_casing_of_paths": True}, None)
     task_path = tmp_path / "task_example.py"

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,10 +1,10 @@
+import sys
 import textwrap
 from contextlib import ExitStack as does_not_raise  # noqa: N813
 from pathlib import Path
 
 import pytest
 from _pytask.collect import pytask_collect_node
-from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.exceptions import NodeNotCollectedError
 from _pytask.session import Session
 from pytask import main
@@ -141,7 +141,7 @@ def test_pytask_collect_node(session, path, node, expectation, expected):
 
 @pytest.mark.unit
 @pytest.mark.skipif(
-    IS_FILE_SYSTEM_CASE_SENSITIVE, reason="Only works on case-insensitive file systems."
+    sys.platform != "win32", reason="Only works on case-insensitive file systems."
 )
 def test_pytask_collect_node_raises_error_if_path_is_not_correctly_cased(tmp_path):
     session = Session({"check_casing_of_paths": True}, None)

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -175,4 +175,6 @@ def test_pytask_collect_node_does_not_raise_warning_if_path_is_not_normalized(tm
     print(Path(tmp_path, "ExA.Txt").resolve())
     print("exists:", Path(tmp_path, "ExA.Txt").exists())
 
+    print(os.listdir(tmp_path))
+
     raise Exception

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 from contextlib import ExitStack as does_not_raise  # noqa: N813
 from pathlib import Path
@@ -153,7 +152,8 @@ def test_pytask_collect_node_raises_warning_if_path_is_not_correctly_cased(tmp_p
 
     with pytest.warns(UserWarning, match="The provided path of"):
         result = pytask_collect_node(session, task_path, collected_node)
-        assert str(result.path) == str(real_node)
+
+    assert str(result.path) == str(real_node)
 
 
 @pytest.mark.unit
@@ -165,17 +165,6 @@ def test_pytask_collect_node_does_not_raise_warning_if_path_is_not_normalized(tm
 
     with pytest.warns(None) as record:
         result = pytask_collect_node(session, task_path, collected_node)
-        assert str(result.path) == str(real_node)
-        assert not record
 
-    print("is case-sesn", IS_FILE_SYSTEM_CASE_SENSITIVE)
-    print(Path(tmp_path, "ExA.Txt").resolve())
-
-    Path(tmp_path, "exa.txt").touch()
-
-    print(Path(tmp_path, "ExA.Txt").resolve())
-    print("exists:", Path(tmp_path, "ExA.Txt").exists())
-
-    print(os.listdir(tmp_path))
-
-    raise Exception
+    assert str(result.path) == str(real_node)
+    assert not record

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -166,3 +166,12 @@ def test_pytask_collect_node_does_not_raise_warning_if_path_is_not_normalized(tm
         result = pytask_collect_node(session, task_path, collected_node)
         assert str(result.path) == str(real_node)
         assert not record
+
+    print("is case-sesn", IS_FILE_SYSTEM_CASE_SENSITIVE)
+    print(Path(tmp_path, "ExA.Txt").resolve())
+
+    Path(tmp_path, "exa.txt").touch()
+
+    print(Path(tmp_path, "ExA.Txt").resolve())
+
+    raise Exception

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 from contextlib import ExitStack as does_not_raise  # noqa: N813
 from pathlib import Path

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -173,5 +173,6 @@ def test_pytask_collect_node_does_not_raise_warning_if_path_is_not_normalized(tm
     Path(tmp_path, "exa.txt").touch()
 
     print(Path(tmp_path, "ExA.Txt").resolve())
+    print("exists:", Path(tmp_path, "ExA.Txt").exists())
 
     raise Exception

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from _pytask.collect import pytask_collect_node
-from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.exceptions import NodeNotCollectedError
 from _pytask.session import Session
 from pytask import main
@@ -140,24 +139,19 @@ def test_pytask_collect_node(session, path, node, expectation, expected):
 
 
 @pytest.mark.unit
-@pytest.mark.skipif(
-    IS_FILE_SYSTEM_CASE_SENSITIVE, reason="Only works on case-insensitive file systems."
-)
-def test_pytask_collect_node_raises_warning_if_path_is_not_correctly_cased(tmp_path):
+def test_pytask_collect_node_raises_error_if_path_is_not_correctly_cased(tmp_path):
     session = Session({"check_casing_of_paths": True}, None)
     task_path = tmp_path / "task_example.py"
     real_node = tmp_path / "text.txt"
     real_node.touch()
     collected_node = tmp_path / "TeXt.TxT"
 
-    with pytest.warns(UserWarning, match="The provided path of"):
-        result = pytask_collect_node(session, task_path, collected_node)
-
-    assert str(result.path) == str(real_node)
+    with pytest.raises(Exception, match="The provided path of"):
+        pytask_collect_node(session, task_path, collected_node)
 
 
 @pytest.mark.unit
-def test_pytask_collect_node_does_not_raise_warning_if_path_is_not_normalized(tmp_path):
+def test_pytask_collect_node_does_not_raise_error_if_path_is_not_normalized(tmp_path):
     session = Session({"check_casing_of_paths": True}, None)
     task_path = tmp_path / "task_example.py"
     real_node = tmp_path / "text.txt"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -8,8 +8,8 @@ from _pytask.nodes import _check_that_names_are_not_used_multiple_times
 from _pytask.nodes import _convert_nodes_to_dictionary
 from _pytask.nodes import _convert_objects_to_list_of_tuples
 from _pytask.nodes import _convert_objects_to_node_dictionary
-from _pytask.nodes import _create_task_name
 from _pytask.nodes import _extract_nodes_from_function_markers
+from _pytask.nodes import create_task_name
 from _pytask.nodes import depends_on
 from _pytask.nodes import FilePathNode
 from _pytask.nodes import MetaNode
@@ -197,7 +197,7 @@ def test_convert_nodes_to_dictionary(x, expected):
     ],
 )
 def test_create_task_name(path, name, expected):
-    result = _create_task_name(path, name)
+    result = create_task_name(path, name)
     assert result == expected
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,6 +5,7 @@ from pathlib import PurePosixPath
 from pathlib import PureWindowsPath
 
 import pytest
+from _pytask.path import _find_case_sensitive_path_on_posix
 from _pytask.path import find_closest_ancestor
 from _pytask.path import find_common_ancestor
 from _pytask.path import relative_to
@@ -89,3 +90,24 @@ def test_find_common_ancestor(path_1, path_2, expectation, expected):
     with expectation:
         result = find_common_ancestor(path_1, path_2)
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "path, existing_paths, expected",
+    [
+        pytest.param("text.txt", [], "text.txt", id="non-existing path stays the same"),
+        pytest.param("text.txt", ["text.txt"], "text.txt", id="existing path is same"),
+        pytest.param("Text.txt", ["text.txt"], "text.txt", id="correct path"),
+        pytest.param(
+            "d/text.txt", ["D/text.txt"], "D/text.txt", id="correct path in folder"
+        ),
+    ],
+)
+def test_find_case_sensitive_path_on_posix(tmp_path, path, existing_paths, expected):
+    for p in [path] + existing_paths:
+        p = tmp_path / p
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+
+    result = _find_case_sensitive_path_on_posix(tmp_path / path)
+    assert result == tmp_path / expected

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 from pathlib import PureWindowsPath
 
 import pytest
-from _pytask.path import _find_case_sensitive_path_on_posix
+from _pytask.path import find_case_sensitive_path
 from _pytask.path import find_closest_ancestor
 from _pytask.path import find_common_ancestor
 from _pytask.path import relative_to
@@ -92,6 +92,8 @@ def test_find_common_ancestor(path_1, path_2, expectation, expected):
         assert result == expected
 
 
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform != "win32", reason="Only works on Windows.")
 @pytest.mark.parametrize(
     "path, existing_paths, expected",
     [
@@ -103,11 +105,11 @@ def test_find_common_ancestor(path_1, path_2, expectation, expected):
         ),
     ],
 )
-def test_find_case_sensitive_path_on_posix(tmp_path, path, existing_paths, expected):
+def test_find_case_sensitive_path(tmp_path, path, existing_paths, expected):
     for p in [path] + existing_paths:
         p = tmp_path / p
         p.parent.mkdir(parents=True, exist_ok=True)
         p.touch()
 
-    result = _find_case_sensitive_path_on_posix(tmp_path / path)
+    result = find_case_sensitive_path(tmp_path / path, sys.platform)
     assert result == tmp_path / expected


### PR DESCRIPTION
#### Changes

- An error is raised on Windows if the casing is wrong.
- No errors on case-insensitive macOS sinceI found no way and tested some approaches. Contributions welcome.
- On case-sensitive systems a hint is shown when nodes cannot be found.
