### PR TITLE
Selecting a task should also run its predecessors.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`116` and :gh:`117` fix :gh:`104` which prevented to skip tasks with missing
   dependencies.
 - :gh:`118` makes the path to the configuration in the session header os-specific.
+- :gh:`119` changes that when marker or keyword expressions are used to select tasks,
+  also the predecessors of the selected tasks will be executed.
 
 
 0.0.16 - 2021-06-25

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -231,12 +231,7 @@ def pytask_collect_log(session, reports, tasks):
     """Log collection."""
     session.collection_end = time.time()
 
-    message = f"Collected {len(tasks)} task{'' if len(tasks) == 1 else 's'}."
-
-    n_deselected = len(session.deselected)
-    if n_deselected:
-        message += f" Deselected {n_deselected} task{'' if n_deselected == 1 else 's'}."
-    console.print(message)
+    console.print(f"Collected {len(tasks)} task{'' if len(tasks) == 1 else 's'}.")
 
     failed_reports = [i for i in reports if not i.successful]
     if failed_reports:
@@ -269,7 +264,6 @@ def pytask_collect_log(session, reports, tasks):
             infos=[
                 (len(tasks), "collected", ColorCode.SUCCESS),
                 (len(failed_reports), "failed", ColorCode.FAILED),
-                (n_deselected, "deselected", ColorCode.NEUTRAL),
             ],
             duration=round(session.collection_end - session.collection_start, 2),
             color=ColorCode.FAILED if len(failed_reports) else ColorCode.SUCCESS,

--- a/src/_pytask/dag.py
+++ b/src/_pytask/dag.py
@@ -30,6 +30,21 @@ def task_and_descending_tasks(
     yield from descending_tasks(task_name, dag)
 
 
+def preceding_tasks(task_name: str, dag: nx.DiGraph) -> Generator[str, None, None]:
+    """Yield only preceding tasks."""
+    for ancestor in nx.ancestors(dag, task_name):
+        if "task" in dag.nodes[ancestor]:
+            yield ancestor
+
+
+def task_and_preceding_tasks(
+    task_name: str, dag: nx.DiGraph
+) -> Generator[str, None, None]:
+    """Yield task and preceding tasks."""
+    yield task_name
+    yield from preceding_tasks(task_name, dag)
+
+
 def node_and_neighbors(dag: nx.DiGraph, node: str) -> Generator[str, None, None]:
     """Yield node and neighbors which are first degree predecessors and successors.
 

--- a/src/_pytask/hookspecs.py
+++ b/src/_pytask/hookspecs.py
@@ -228,7 +228,7 @@ def pytask_resolve_dependencies_create_dag(session, tasks):
     """
 
 
-@hookspec(firstresult=True)
+@hookspec
 def pytask_resolve_dependencies_select_execution_dag(session, dag):
     """Select the subgraph which needs to be executed.
 

--- a/src/_pytask/hookspecs.py
+++ b/src/_pytask/hookspecs.py
@@ -229,11 +229,11 @@ def pytask_resolve_dependencies_create_dag(session, tasks):
 
 
 @hookspec
-def pytask_resolve_dependencies_select_execution_dag(session, dag):
-    """Select the subgraph which needs to be executed.
+def pytask_resolve_dependencies_modify_dag(session, dag):
+    """Modify the DAG.
 
-    This hook determines which of the tasks have to be re-run because something has
-    changed.
+    This hook allows to make some changes to the DAG before it is validated and tasks
+    are selected.
 
     """
 
@@ -244,6 +244,16 @@ def pytask_resolve_dependencies_validate_dag(session, dag):
 
     This hook validates the DAG. For example, there can be cycles in the DAG if tasks,
     dependencies and products have been misspecified.
+
+    """
+
+
+@hookspec
+def pytask_resolve_dependencies_select_execution_dag(session, dag):
+    """Select the subgraph which needs to be executed.
+
+    This hook determines which of the tasks have to be re-run because something has
+    changed.
 
     """
 

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -241,7 +241,7 @@ def _deselect_others_with_mark(session, remaining, mark):
 
 
 @hookimpl
-def pytask_resolve_dependencies_select_execution_dag(session, dag):
+def pytask_resolve_dependencies_modify_dag(session, dag):
     """Modify the tasks which are executed with expressions and markers."""
     remaining = select_by_keyword(session, dag)
     if remaining is not None:

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -55,7 +55,7 @@ def pytask_resolve_dependencies(session):
         session.hook.pytask_resolve_dependencies_log(session=session, report=report)
         session.resolving_dependencies_report = report
 
-        raise ResolvingDependenciesError
+        raise ResolvingDependenciesError from None
 
     else:
         return True
@@ -209,7 +209,7 @@ def _check_if_root_nodes_are_available(dag):
             dictionary[short_node_name] = short_successors
 
         text = _format_dictionary_to_tree(dictionary, "Missing dependencies:")
-        raise ResolvingDependenciesError(_TEMPLATE_ERROR.format(text))
+        raise ResolvingDependenciesError(_TEMPLATE_ERROR.format(text)) from None
 
 
 def _check_if_tasks_are_skipped(node, dag, is_task_skipped):

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -43,6 +43,9 @@ def pytask_resolve_dependencies(session):
         session.dag = session.hook.pytask_resolve_dependencies_create_dag(
             session=session, tasks=session.tasks
         )
+        session.hook.pytask_resolve_dependencies_modify_dag(
+            session=session, dag=session.dag
+        )
         session.hook.pytask_resolve_dependencies_validate_dag(
             session=session, dag=session.dag
         )
@@ -77,6 +80,8 @@ def pytask_resolve_dependencies_create_dag(tasks):
             dag.add_node(product.name, node=product)
             dag.add_edge(task.name, product.name)
 
+    _check_if_dag_has_cycles(dag)
+
     return dag
 
 
@@ -100,7 +105,6 @@ def pytask_resolve_dependencies_select_execution_dag(dag):
 @hookimpl
 def pytask_resolve_dependencies_validate_dag(dag):
     """Validate the DAG."""
-    _check_if_dag_has_cycles(dag)
     _check_if_root_nodes_are_available(dag)
     _check_if_tasks_have_the_same_products(dag)
 

--- a/src/_pytask/session.py
+++ b/src/_pytask/session.py
@@ -18,8 +18,6 @@ class Session:
     """
     tasks = attr.ib(factory=list)
     """Optional[List[pytask.nodes.MetaTask]]: List of collected tasks."""
-    deselected = attr.ib(factory=list)
-    """Optional[List[pytask.nodes.MetaTask]]: list of deselected tasks."""
     resolving_dependencies_report = attr.ib(factory=list)
     """Optional[pytask.report.ResolvingDependenciesReport]: A report.
 

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -20,6 +20,7 @@ def test_collect_task(runner, tmp_path):
         pass
     """
     tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in.txt").touch()
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
 
@@ -53,6 +54,7 @@ def test_collect_parametrized_tasks(runner, tmp_path):
         pass
     """
     tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in.txt").touch()
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
 
@@ -80,6 +82,8 @@ def test_collect_task_with_expressions(runner, tmp_path):
         pass
     """
     tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
+    tmp_path.joinpath("in_2.txt").touch()
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "-k", "_1"])
 
@@ -122,6 +126,7 @@ def test_collect_task_with_marker(runner, tmp_path, config_name):
         pass
     """
     tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
 
     config = """
     [pytask]
@@ -176,6 +181,7 @@ def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
         pass
     """
     tmp_path.joinpath("task_dummy_2.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
 
     config = """
     [pytask]
@@ -220,6 +226,7 @@ def test_collect_task_with_ignore_from_cli(runner, tmp_path):
         pass
     """
     tmp_path.joinpath("task_dummy_1.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
 
     source = """
     @pytask.mark.depends_on("in_2.txt")


### PR DESCRIPTION
Closes #98.

- [x]  Remove deselection and so on while logging collection.