### PR TITLE
Show reports from previously executed tasks on KeyboardInterrupt.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`116` and :gh:`117` fix :gh:`104` which prevented to skip tasks with missing
   dependencies.
 - :gh:`118` makes the path to the configuration in the session header os-specific.
+- :gh:`120` implements that a single ``KeyboardInterrupt`` stops the execution and
+  previously collected reports are shown.
 
 
 0.0.16 - 2021-06-25

--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -14,6 +14,7 @@ from _pytask.mark import Mark
 from _pytask.nodes import FilePathNode
 from _pytask.report import ExecutionReport
 from _pytask.shared import reduce_node_name
+from _pytask.traceback import remove_traceback_from_exc_info
 from rich.traceback import Traceback
 
 
@@ -68,7 +69,8 @@ def pytask_execute_task_protocol(session, task):
         session.hook.pytask_execute_task(session=session, task=task)
         session.hook.pytask_execute_task_teardown(session=session, task=task)
     except KeyboardInterrupt:
-        report = ExecutionReport.from_task_and_exception(task, sys.exc_info())
+        short_exc_info = remove_traceback_from_exc_info(sys.exc_info())
+        report = ExecutionReport.from_task_and_exception(task, short_exc_info)
         session.should_stop = True
     except Exception:
         report = ExecutionReport.from_task_and_exception(task, sys.exc_info())

--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -67,6 +67,9 @@ def pytask_execute_task_protocol(session, task):
         session.hook.pytask_execute_task_setup(session=session, task=task)
         session.hook.pytask_execute_task(session=session, task=task)
         session.hook.pytask_execute_task_teardown(session=session, task=task)
+    except KeyboardInterrupt:
+        report = ExecutionReport.from_task_and_exception(task, sys.exc_info())
+        session.should_stop = True
     except Exception:
         report = ExecutionReport.from_task_and_exception(task, sys.exc_info())
     else:

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -167,5 +167,4 @@ class LiveCollection:
         if self._n_errors > 0:
             msg += f" {self._n_errors} errors."
         status = Status(msg, spinner="dots")
-        status._name = "collection_status"
         return status

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -97,4 +97,6 @@ def _style_infos(infos: List[Tuple[Any]]) -> str:
     for value, description, color in infos:
         if value:
             message.append(f"[{color}]{value} {description}[/]")
+    if not message:
+        message = ["nothing to report"]
     return ", ".join(message)


### PR DESCRIPTION
Closes #111.

- [x] Short traceback for interrupted task.
- [x] If no tasks were executed, fix session footer.
- [x] How does it relate to parallel execution?
