### PR TITLE
Enable rich's auto-refresh for live displays.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,12 @@ repos:
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.21.2
+    rev: v2.23.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.5.0
+    rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/setup-cfg-fmt

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,11 +7,13 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 `Anaconda.org <https://anaconda.org/conda-forge/pytask>`_.
 
 
-0.1.1 - 2021-xx-xx
+0.1.1 - 2021-08-25
 ------------------
 
 - :gh:`138` changes the default verbosity to ``1`` which displays the live table during
   execution and ``0`` display the symbols for outcomes (e.g. ``.``, ``F``, ``s``).
+- :gh:`139` enables rich's auto-refresh mechanism for live objects which causes almost
+  no performance penalty for the live table compared to the symbolic output.
 
 
 0.1.0 - 2021-07-20

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -33,7 +33,7 @@ class LiveManager:
 
     """
 
-    _live = Live(renderable=None, console=console, auto_refresh=False)
+    _live = Live(renderable=None, console=console, auto_refresh=True)
 
     def start(self):
         self._live.start()
@@ -55,9 +55,6 @@ class LiveManager:
 
     def update(self, *args, **kwargs):
         self._live.update(*args, **kwargs)
-
-    def refresh(self):
-        self._live.refresh()
 
     @property
     def is_started(self):
@@ -105,7 +102,6 @@ class LiveExecution:
     def _update_table(self):
         table = self._generate_table()
         self._live_manager.update(table)
-        self._live_manager.refresh()
 
     def update_running_tasks(self, new_running_task):
         reduced_task_name = reduce_node_name(new_running_task, self._paths)
@@ -160,7 +156,6 @@ class LiveCollection:
     def _update_status(self):
         status = self._generate_status()
         self._live_manager.update(status)
-        self._live_manager.refresh()
 
     def _generate_status(self):
         msg = f"Collected {self._n_collected_tasks} tasks."


### PR DESCRIPTION
Closes #137.

I tested performance by parametrizing a dummy task with ``range(200)``. The former version took 50s with the live table and using rich's auto-refresh decreased runtime to 5s which is 1s-2s higher than the symbolic output.