### PR TITLE
Limit number of items in the execution table during the execution.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -14,6 +14,9 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
   table for the default verbosity level of 1. They are displayed at 2.
 - :gh:`144` adds tryceratops to the pre-commit hooks for catching issues with
   exceptions.
+- :gh:`150` adds a limit on the number of items displayed in the execution table which
+  is also configurable with ``--n-entries-in-table`` on the cli and
+  ``n_entries_in_table`` in the configuration file.
 
 
 0.1.1 - 2021-08-25

--- a/docs/source/reference_guides/configuration.rst
+++ b/docs/source/reference_guides/configuration.rst
@@ -97,6 +97,23 @@ The options
             wip: Work-in-progress. These are tasks which I am currently working on.
 
 
+.. confval:: n_entries_in_table
+
+    You can limit the number of entries displayed in the live table during the execution
+    to make it more clear. Use either ``all`` or an integer greater or equal to one. On
+    the command line use
+
+    .. code-block:: console
+
+        $ pytask build --n-entries-in-tabl 10
+
+    and in the configuration use
+
+    .. code-block:: ini
+
+        n_entries_in_table = all  # default 15
+
+
 .. confval:: paths
 
     If you want to collect tasks from specific paths without passing the names via the

--- a/docs/source/reference_guides/configuration.rst
+++ b/docs/source/reference_guides/configuration.rst
@@ -105,7 +105,7 @@ The options
 
     .. code-block:: console
 
-        $ pytask build --n-entries-in-tabl 10
+        $ pytask build --n-entries-in-table 10
 
     and in the configuration use
 

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -274,7 +274,7 @@ class PytaskPDB:
         return PytaskPdbWrapper
 
     @classmethod
-    def _init_pdb(cls, method, *args, **kwargs):
+    def _init_pdb(cls, method, *args, **kwargs):  # noqa: U100
         """Initialize PDB debugging, dropping any IO capturing."""
         if cls._pluginmanager is None:
             capman = None

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -1,13 +1,42 @@
 from pathlib import Path
+from typing import Union
 
 import attr
 from _pytask.config import hookimpl
 from _pytask.console import console
+from _pytask.shared import get_first_non_none_value
 from _pytask.shared import reduce_node_name
 from rich.live import Live
 from rich.status import Status
 from rich.table import Table
 from rich.text import Text
+
+
+@hookimpl
+def pytask_parse_config(config, config_from_cli, config_from_file):
+    config["n_entries_in_table"] = get_first_non_none_value(
+        config_from_cli,
+        config_from_file,
+        key="n_entries_in_table",
+        default=20,
+        callback=_parse_n_entries_in_table,
+    )
+
+
+def _parse_n_entries_in_table(value: Union[int, str, None]) -> int:
+    if value in ["none", "None", None, ""]:
+        out = None
+    elif isinstance(value, int) and value >= 1:
+        out = value
+    elif isinstance(value, str) and value.isdigit() and int(value) >= 1:
+        out = int(value)
+    elif value == "all":
+        out = 1_000_000
+    else:
+        raise ValueError(
+            "'n_entries_in_table' can either be 'None' or an integer bigger than one."
+        )
+    return out
 
 
 @hookimpl

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -21,7 +21,7 @@ def pytask_extend_command_line_interface(cli):
             ["--n-entries-in-table"],
             default=None,
             help="How many entries to display in the table during the execution. "
-            "Tasks which are running are always displayed.",
+            "Tasks which are running are always displayed.  [default: 15]",
         ),
     ]
     cli.commands["build"].params.extend(additional_parameters)
@@ -33,7 +33,7 @@ def pytask_parse_config(config, config_from_cli, config_from_file):
         config_from_cli,
         config_from_file,
         key="n_entries_in_table",
-        default=20,
+        default=15,
         callback=_parse_n_entries_in_table,
     )
 

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Union
 
 import attr
+import click
 from _pytask.config import hookimpl
 from _pytask.console import console
 from _pytask.shared import get_first_non_none_value
@@ -10,6 +11,20 @@ from rich.live import Live
 from rich.status import Status
 from rich.table import Table
 from rich.text import Text
+
+
+@hookimpl
+def pytask_extend_command_line_interface(cli):
+    """Extend command line interface."""
+    additional_parameters = [
+        click.Option(
+            ["--n-entries-in-table"],
+            default=None,
+            help="How many entries to display in the table during the execution. "
+            "Tasks which are running are always displayed.",
+        ),
+    ]
+    cli.commands["build"].params.extend(additional_parameters)
 
 
 @hookimpl

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,11 +1,41 @@
 import textwrap
+from contextlib import ExitStack as does_not_raise  # noqa: N813
 
 import pytest
+from _pytask.live import _parse_n_entries_in_table
 from _pytask.live import LiveExecution
 from _pytask.live import LiveManager
 from _pytask.nodes import PythonFunctionTask
 from _pytask.report import ExecutionReport
 from pytask import cli
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value, expectation, expected",
+    [
+        pytest.param(None, does_not_raise(), None, id="none parsed"),
+        pytest.param(3, does_not_raise(), 3, id="int parsed"),
+        pytest.param("10", does_not_raise(), 10, id="string int parsed"),
+        pytest.param("all", does_not_raise(), 1_000_000, id="all to large int"),
+        pytest.param(
+            -1,
+            pytest.raises(ValueError, match="'n_entries_in_table' can"),
+            None,
+            id="negative int raises error",
+        ),
+        pytest.param(
+            "-1",
+            pytest.raises(ValueError, match="'n_entries_in_table' can"),
+            None,
+            id="negative int raises error",
+        ),
+    ],
+)
+def test_parse_n_entries_in_table(value, expectation, expected):
+    with expectation:
+        result = _parse_n_entries_in_table(value)
+        assert result == expected
 
 
 @pytest.mark.end_to_end

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -24,7 +24,7 @@ def test_pytask_mark_notcallable() -> None:
 @pytest.mark.unit
 @pytest.mark.filterwarnings("ignore:Unknown pytask.mark.foo")
 def test_mark_with_param():
-    def some_function(abc):
+    def some_function():
         pass
 
     class SomeClass:

--- a/tests/test_mark_expression.py
+++ b/tests/test_mark_expression.py
@@ -11,10 +11,10 @@ def evaluate(input_: str, matcher: Callable[[str], bool]) -> bool:
 
 @pytest.mark.unit
 def test_empty_is_false() -> None:
-    assert not evaluate("", lambda ident: False)
-    assert not evaluate("", lambda ident: True)
-    assert not evaluate("   ", lambda ident: False)
-    assert not evaluate("\t", lambda ident: False)
+    assert not evaluate("", lambda ident: False)  # noqa: U100
+    assert not evaluate("", lambda ident: True)  # noqa: U100
+    assert not evaluate("   ", lambda ident: False)  # noqa: U100
+    assert not evaluate("\t", lambda ident: False)  # noqa: U100
 
 
 @pytest.mark.unit
@@ -119,7 +119,7 @@ def test_syntax_oddeties(expr: str, expected: bool) -> None:
 )
 def test_syntax_errors(expr: str, column: int, message: str) -> None:
     with pytest.raises(ParseError) as excinfo:
-        evaluate(expr, lambda ident: True)
+        evaluate(expr, lambda ident: True)  # noqa: U100
     assert excinfo.value.column == column
     assert excinfo.value.message == message
 
@@ -183,4 +183,4 @@ def test_valid_idents(ident: str) -> None:
 )
 def test_invalid_idents(ident: str) -> None:
     with pytest.raises(ParseError):
-        evaluate(ident, lambda ident: True)
+        evaluate(ident, lambda ident: True)  # noqa: U100

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -33,7 +33,7 @@ def session():
 @pytest.mark.integration
 def test_pytask_generate_tasks_0(session):
     @pytask.mark.parametrize("i", range(2))
-    def func(i):
+    def func(i):  # noqa: U100
         pass
 
     names_and_objs = pytask_parametrize_task(session, "func", func)
@@ -48,7 +48,7 @@ def test_pytask_generate_tasks_0(session):
 def test_pytask_generate_tasks_1(session):
     @pytask.mark.parametrize("j", range(2))
     @pytask.mark.parametrize("i", range(2))
-    def func(i, j):
+    def func(i, j):  # noqa: U100
         pass
 
     names_and_objs = pytask_parametrize_task(session, "func", func)
@@ -66,7 +66,7 @@ def test_pytask_generate_tasks_1(session):
 def test_pytask_generate_tasks_2(session):
     @pytask.mark.parametrize("j, k", itertools.product(range(2), range(2)))
     @pytask.mark.parametrize("i", range(2))
-    def func(i, j, k):
+    def func(i, j, k):  # noqa: U100
         pass
 
     names_and_objs = pytask_parametrize_task(session, "func", func)


### PR DESCRIPTION
Closes #149.

#### Changes

This PR adds another option ``n_entries_in_table`` to limit the number of items in the execution table. All running tasks are always displayed and the remaining slots are eventually filled up with completed tasks.