### PR TITLE
Make duration human readable.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -14,6 +14,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
   table for the default verbosity level of 1. They are displayed at 2.
 - :gh:`144` adds tryceratops to the pre-commit hooks for catching issues with
   exceptions.
+- :gh:`152` makes the duration of the execution readable by humans by separating it into
+  days, hours, minutes and seconds.
 
 
 0.1.1 - 2021-08-25

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -274,7 +274,7 @@ class PytaskPDB:
         return PytaskPdbWrapper
 
     @classmethod
-    def _init_pdb(cls, method, *args, **kwargs):
+    def _init_pdb(cls, method, *args, **kwargs):  # noqa: U100
         """Initialize PDB debugging, dropping any IO capturing."""
         if cls._pluginmanager is None:
             capman = None

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -113,8 +113,8 @@ _TIME_UNITS = [
 def _format_duration(duration):
     duration_tuples = _humanize_time(duration, "seconds", short_label=False)
 
-    # Remove seconds if the execution lasted days.
-    if duration_tuples[0][1] in ["day", "days"]:
+    # Remove seconds if the execution lasted days or hours.
+    if duration_tuples[0][1] in ["day", "days", "hour", "hours"]:
         duration_tuples = [
             i for i in duration_tuples if i[1] not in ["second", "seconds"]
         ]

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -99,3 +99,54 @@ def _style_infos(infos: List[Tuple[Any]]) -> str:
     if not message:
         message = ["nothing to report"]
     return ", ".join(message)
+
+
+_TIME_UNITS = [
+    {"singular": "day", "plural": "days", "short": "d", "in_seconds": 86400},
+    {"singular": "hour", "plural": "hours", "short": "h", "in_seconds": 3600},
+    {"singular": "minute", "plural": "minutes", "short": "m", "in_seconds": 60},
+    {"singular": "second", "plural": "seconds", "short": "s", "in_seconds": 1},
+]
+
+
+def _humanize_time(amount: int, unit: str, short_label: bool = False):
+    """Humanize the time.
+
+    Examples
+    --------
+    >>> _humanize_time(173, "hours")
+    [(7, 'days'), (5, 'hours')]
+    >>> _humanize_time(173, "hours", short_label=True)
+    [(7, 'd'), (5, 'h')]
+    >>> _humanize_time(1, "unknown_unit")
+    Traceback (most recent call last):
+    ...
+    ValueError: The time unit 'unknown_unit' is not known.
+
+    """
+    index = None
+    for i, entry in enumerate(_TIME_UNITS):
+        if unit in [entry["singular"], entry["plural"]]:
+            index = i
+            break
+    else:
+        raise ValueError(f"The time unit '{unit}' is not known.")
+
+    seconds = amount * _TIME_UNITS[index]["in_seconds"]
+
+    result = []
+    remaining_seconds = seconds
+    for entry in _TIME_UNITS:
+        whole_units = remaining_seconds // entry["in_seconds"]
+        if whole_units >= 1:
+            if short_label:
+                label = entry["short"]
+            elif whole_units == 1:
+                label = entry["singular"]
+            else:
+                label = entry["plural"]
+
+            result.append((whole_units, label))
+            remaining_seconds -= whole_units * entry["in_seconds"]
+
+    return result

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -266,7 +266,7 @@ def test_capturing_outerr(tmp_path, runner):
         "1",
         "──────────────────────── Captured stderr during call ────────────────────────",
         "2",
-        "────────────────────── 1 succeeded, 1 failed in 0.",
+        "─────────── 1 succeeded, 1 failed in 0 seconds ────────",
     ]:
         assert content in result.output
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -35,13 +35,25 @@ def test_format_plugin_names_and_versions(plugins, expected):
             [(1, "succeeded", "green"), (1, "failed", "red")],
             1,
             "red",
-            "────── 1 succeeded, 1 failed in 1s ───────────",
+            "────── 1 succeeded, 1 failed in 1 second ───────────",
         ),
         (
             [(2, "succeeded", "green"), (1, "skipped", "yellow")],
             10,
             "green",
-            "────── 2 succeeded, 1 skipped in 10s ───────────",
+            "────── 2 succeeded, 1 skipped in 10 seconds ───────────",
+        ),
+        (
+            [(2, "succeeded", "green"), (1, "skipped", "yellow")],
+            5400,
+            "green",
+            "────── 2 succeeded, 1 skipped in 1 hour, 30 minutes ───────────",
+        ),
+        (
+            [(2, "succeeded", "green"), (1, "skipped", "yellow")],
+            125_000,
+            "green",
+            "────── 2 succeeded, 1 skipped in 1 day, 10 hours, 43 minutes ───────────",
         ),
     ],
 )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,7 +45,7 @@ def test_format_plugin_names_and_versions(plugins, expected):
         ),
         (
             [(2, "succeeded", "green"), (1, "skipped", "yellow")],
-            5400,
+            5401,
             "green",
             "────── 2 succeeded, 1 skipped in 1 hour, 30 minutes ───────────",
         ),


### PR DESCRIPTION
#### Changes

The duration is currently displayed in seconds which can be unreadable when the duration exceeds multiple hours and even days.

This PR implements a human readable time stamp.