### PR TITLE
Make task ids clickable with URLs pointing to the function.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -16,7 +16,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`163` allow forward slashes in expressions and marker expressions.
 - :gh:`164` allows to use backward slashes in expressions and marker expressions.
 - :gh:`167` makes small changes to the docs.
-- :gh:`172` embeds URLs in task ids.
+- :gh:`172` embeds URLs in task ids. See :confval:`editor_url_scheme` for more
+  information.
 
 
 0.1.3 - 2021-11-30
@@ -35,20 +36,21 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`144` adds tryceratops to the pre-commit hooks for catching issues with
   exceptions.
 - :gh:`150` adds a limit on the number of items displayed in the execution table which
-  is also configurable with ``--n-entries-in-table`` on the cli and
-  ``n_entries_in_table`` in the configuration file.
+  is configurable with :confval:`n_entries_in_table` in the configuration file.
 - :gh:`152` makes the duration of the execution readable by humans by separating it into
   days, hours, minutes and seconds.
 - :gh:`155` implements functions to check for optional packages and programs and raises
   errors for requirements to draw the DAG earlier.
-- :gh:`156` adds an option to print/show errors as soon as they occur.
+- :gh:`156` adds the option :confval:`show_errors_immediately` to print/show errors as
+  soon as they occur.
 
 
 0.1.1 - 2021-08-25
 ------------------
 
-- :gh:`138` changes the default verbosity to ``1`` which displays the live table during
-  execution and ``0`` display the symbols for outcomes (e.g. ``.``, ``F``, ``s``).
+- :gh:`138` changes the default :confval:`verbosity` to ``1`` which displays the live
+  table during execution and ``0`` display the symbols for outcomes (e.g. ``.``, ``F``,
+  ``s``).
 - :gh:`139` enables rich's auto-refresh mechanism for live objects which causes almost
   no performance penalty for the live table compared to the symbolic output.
 
@@ -86,25 +88,28 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`80` replaces some remaining formatting using ``pprint`` with ``rich``.
 - :gh:`81` adds a warning if a path is not correctly cased on a case-insensitive file
   system. This facilitates cross-platform builds of projects. Deactivate the check by
-  setting ``check_casing_of_paths = false`` in the configuration file.
+  setting ``check_casing_of_paths = false`` in the configuration file. See
+  :confval:`check_casing_of_paths` for more information.
 - :gh:`83` replaces ``versioneer`` with ``setuptools_scm``.
 - :gh:`84` fixes an error in the path normalization introduced by :gh:`81`.
 - :gh:`85` sorts collected tasks, dependencies, and products by name.
 - :gh:`87` fixes that dirty versions are displayed in the documentation.
-- :gh:`88` adds a ``profile`` command to show information on tasks like duration and
-  file size of products.
+- :gh:`88` adds the ``pytask profile`` command to show information on tasks like
+  duration and file size of products.
 - :gh:`93` fixes the display of parametrized arguments in the console.
-- :gh:`94` adds ``--show-locals`` which allows to print local variables in tracebacks.
+- :gh:`94` adds :confval:`show_locals` which allows to print local variables in
+  tracebacks.
 - :gh:`96` implements a spinner to show the progress during the collection.
-- :gh:`99` enables color support in WSL and fixes ``show_locals`` during collection.
+- :gh:`99` enables color support in WSL and fixes :confval:`show_locals` during
+  collection.
 - :gh:`101` implement to visualize the project's DAG. :gh:`108` refines the
   implementation.
 - :gh:`102` adds an example if a parametrization provides not the number of arguments
   specified in the signature.
 - :gh:`105` simplifies the logging of the tasks.
-- :gh:`107` adds and new hook ``pytask_unconfigure`` which makes pytask return
-  :func:`pdb.set_trace` at the end of a session which allows to use ``breakpoint()``
-  inside test functions using pytask.
+- :gh:`107` adds and new hook :func:`~_pytask.hookspecs.pytask_unconfigure` which makes
+  pytask return :func:`pdb.set_trace` at the end of a session which allows to use
+  :func:`breakpoint` inside test functions using pytask.
 - :gh:`109` makes pytask require networkx>=2.4 since previous versions fail with Python
   3.9.
 - :gh:`110` adds a "New Features" section to the ``README.rst``.
@@ -125,7 +130,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 
 - :gh:`72` adds conda-forge to the README and highlights importance of specifying
   dependencies and products.
-- :gh:`62` implements the ``pytask.mark.skipif`` marker to conditionally skip tasks.
+- :gh:`62` implements the :func:`pytask.mark.skipif` marker to conditionally skip tasks.
   Many thanks to :ghuser:`roecla` for implementing this feature and a warm welcome since
   she is the first pytask contributor!
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -16,6 +16,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`163` allow forward slashes in expressions and marker expressions.
 - :gh:`164` allows to use backward slashes in expressions and marker expressions.
 - :gh:`167` makes small changes to the docs.
+- :gh:`172` embeds URLs in task ids.
 
 
 0.1.3 - 2021-11-30

--- a/docs/source/reference_guides/configuration.rst
+++ b/docs/source/reference_guides/configuration.rst
@@ -51,6 +51,39 @@ The options
         Contributions are welcome to also support macOS.
 
 
+.. confval:: editor_url_scheme
+
+    Depending on your terminal, pytask is able to turn task ids into clickable links to
+    the modules in which tasks are defined. By default, following the link will open the
+    module with your default application. It is done with
+
+    .. code-block:: ini
+
+        editor_url_scheme = file
+
+    If you use ``vscode`` or ``pycharm`` instead, the file will be opened in the
+    specified editor and the cursor will also jump to the corresponding line.
+
+    .. code-block:: ini
+
+        editor_url_scheme = vscode | pycharm
+
+    For complete flexibility, you can also enter a custom url which can use the
+    variables ``path`` and ``line_number`` to open the file.
+
+    .. code-block:: ini
+
+        editor_url_scheme = editor://{path}:{line_number}
+
+    Maybe you want to contribute this URL scheme to make it available to more people.
+
+    To disable links, use
+
+    .. code-block:: ini
+
+        editor_url_scheme = no_link
+
+
 .. confval:: ignore
 
     pytask can ignore files and directories and exclude some tasks or reduce the

--- a/src/_pytask/collect_command.py
+++ b/src/_pytask/collect_command.py
@@ -189,14 +189,21 @@ def _print_collected_tasks(
         reduced_module = relative_to(module, common_ancestor)
         url_style = create_url_style_for_path(module, editor_url_scheme)
         module_branch = tree.add(
-            Text(f"{PYTHON_ICON}<Module {reduced_module}>", style=url_style)
+            Text.assemble(
+                PYTHON_ICON, "<Module ", Text(str(reduced_module), style=url_style), ">"
+            )
         )
 
         for task in tasks:
             reduced_task_name = reduce_node_name(task, [common_ancestor])
             url_style = create_url_style_for_task(task, editor_url_scheme)
             task_branch = module_branch.add(
-                Text(f"{TASK_ICON}<Function {reduced_task_name}>", style=url_style)
+                Text.assemble(
+                    TASK_ICON,
+                    "<Function ",
+                    Text(reduced_task_name, style=url_style),
+                    ">",
+                ),
             )
 
             if show_nodes:
@@ -204,9 +211,11 @@ def _print_collected_tasks(
                     reduced_node_name = relative_to(node.path, common_ancestor)
                     url_style = create_url_style_for_path(node.path, editor_url_scheme)
                     task_branch.add(
-                        Text(
-                            f"{FILE_ICON}<Dependency {reduced_node_name}>",
-                            style=url_style,
+                        Text.assemble(
+                            FILE_ICON,
+                            "<Dependency ",
+                            Text(str(reduced_node_name), style=url_style),
+                            ">",
                         )
                     )
 
@@ -214,8 +223,11 @@ def _print_collected_tasks(
                     reduced_node_name = relative_to(node.path, common_ancestor)
                     url_style = create_url_style_for_path(node.path, editor_url_scheme)
                     task_branch.add(
-                        Text(
-                            f"{FILE_ICON}<Product {reduced_node_name}>", style=url_style
+                        Text.assemble(
+                            FILE_ICON,
+                            "<Product ",
+                            Text(str(reduced_node_name), style=url_style),
+                            ">",
                         )
                     )
 

--- a/src/_pytask/collect_command.py
+++ b/src/_pytask/collect_command.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 import click
 from _pytask.config import hookimpl
 from _pytask.console import console
+from _pytask.console import create_url_style_for_path
+from _pytask.console import create_url_style_for_task
 from _pytask.console import FILE_ICON
 from _pytask.console import PYTHON_ICON
 from _pytask.console import TASK_ICON
@@ -25,6 +27,7 @@ from _pytask.path import relative_to
 from _pytask.pluginmanager import get_plugin_manager
 from _pytask.session import Session
 from _pytask.shared import reduce_node_name
+from rich.text import Text
 from rich.tree import Tree
 
 
@@ -78,11 +81,16 @@ def collect(**config_from_cli: Optional[Any]) -> "NoReturn":
             tasks = _select_tasks_by_expressions_and_marker(session)
 
             common_ancestor = _find_common_ancestor_of_all_nodes(
-                tasks, session.config["paths"]
+                tasks, session.config["paths"], session.config["nodes"]
             )
-            dictionary = _organize_tasks(tasks, common_ancestor)
+            dictionary = _organize_tasks(tasks)
             if dictionary:
-                _print_collected_tasks(dictionary, session.config["nodes"])
+                _print_collected_tasks(
+                    dictionary,
+                    session.config["nodes"],
+                    session.config["editor_url_scheme"],
+                    common_ancestor,
+                )
 
             console.print()
             console.rule(style=ColorCode.NEUTRAL)
@@ -102,6 +110,7 @@ def collect(**config_from_cli: Optional[Any]) -> "NoReturn":
 
 
 def _select_tasks_by_expressions_and_marker(session: Session) -> "List[MetaTask]":
+    """Select tasks by expressions and marker."""
     all_tasks = {task.name for task in session.tasks}
     remaining_by_mark = select_by_mark(session, session.dag) or all_tasks
     remaining_by_keyword = select_by_keyword(session, session.dag) or all_tasks
@@ -111,84 +120,103 @@ def _select_tasks_by_expressions_and_marker(session: Session) -> "List[MetaTask]
 
 
 def _find_common_ancestor_of_all_nodes(
-    tasks: "List[MetaTask]", paths: List[Path]
+    tasks: "List[MetaTask]", paths: List[Path], show_nodes: bool
 ) -> Path:
     """Find common ancestor from all nodes and passed paths."""
     all_paths = []
     for task in tasks:
-        all_paths += [task.path] + [
-            node.path
-            for attr in ("depends_on", "produces")
-            for node in getattr(task, attr).values()
-        ]
+        all_paths.append(task.path)
+        if show_nodes:
+            all_paths.extend(
+                [
+                    node.path
+                    for attr in ("depends_on", "produces")
+                    for node in getattr(task, attr).values()
+                ]
+            )
 
     common_ancestor = find_common_ancestor(*all_paths, *paths)
 
     return common_ancestor
 
 
-def _organize_tasks(
-    tasks: "List[MetaTask]", common_ancestor: Path
-) -> "Dict[Path, Dict[str, Dict[str, List[Path]]]]":
+def _organize_tasks(tasks: List["MetaTask"]) -> Dict[Path, List["MetaTask"]]:
     """Organize tasks in a dictionary.
 
     The dictionary has file names as keys and then a dictionary with task names and
     below a dictionary with dependencies and targets.
 
     """
-    dictionary: "Dict[Path, Dict[str, Dict[str, List[Path]]]]" = {}
+    dictionary: Dict[Path, List["MetaTask"]] = {}
     for task in tasks:
-        reduced_task_path = relative_to(task.path, common_ancestor)
-        reduced_task_name = reduce_node_name(task, [common_ancestor])
-        dictionary[reduced_task_path] = dictionary.get(reduced_task_path, {})
+        dictionary[task.path] = dictionary.get(task.path, [])
+        dictionary[task.path].append(task)
 
-        task_dict = {
-            reduced_task_name: {
-                "depends_on": sorted(
-                    relative_to(node.path, common_ancestor)
-                    for node in task.depends_on.values()
-                ),
-                "produces": sorted(
-                    relative_to(node.path, common_ancestor)
-                    for node in task.produces.values()
-                ),
-            }
-        }
+    sorted_dict = {}
+    for k in sorted(dictionary):
+        sorted_dict[k] = sorted(dictionary[k], key=lambda x: x.path)
 
-        dictionary[reduced_task_path].update(task_dict)
-
-    dictionary = {key: dictionary[key] for key in sorted(dictionary)}
-
-    return dictionary
+    return sorted_dict
 
 
 def _print_collected_tasks(
-    dictionary: "Dict[Path, Dict[str, Dict[str, List[Path]]]]", show_nodes: bool
+    dictionary: Dict[Path, List["MetaTask"]],
+    show_nodes: bool,
+    editor_url_scheme: str,
+    common_ancestor: Path,
 ) -> None:
     """Print the information on collected tasks.
 
     Parameters
     ----------
-    dictionary: dict
+    dictionary : Dict[Path, List["MetaTask"]]
         A dictionary with path on the first level, tasks on the second, dependencies and
         products on the third.
-    show_nodes: bool
+    show_nodes : bool
         Indicator for whether dependencies and products should be displayed.
+    editor_url_scheme : str
+        The scheme to create an url.
+    common_ancestor : Path
+        The path common to all tasks and nodes.
 
     """
     # Have a new line between the number of collected tasks and this info.
     console.print()
 
     tree = Tree("Collected tasks:", highlight=True)
-    for path in dictionary:
-        module_branch = tree.add(PYTHON_ICON + f"<Module {path}>")
-        for task in dictionary[path]:
-            task_branch = module_branch.add(TASK_ICON + f"<Function {task}>")
-            if show_nodes:
-                for dependency in dictionary[path][task]["depends_on"]:
-                    task_branch.add(FILE_ICON + f"<Dependency {dependency}>")
 
-                for product in dictionary[path][task]["produces"]:
-                    task_branch.add(FILE_ICON + f"<Product {product}>")
+    for module, tasks in dictionary.items():
+        reduced_module = relative_to(module, common_ancestor)
+        url_style = create_url_style_for_path(module, editor_url_scheme)
+        module_branch = tree.add(
+            Text(f"{PYTHON_ICON}<Module {reduced_module}>", style=url_style)
+        )
+
+        for task in tasks:
+            reduced_task_name = reduce_node_name(task, [common_ancestor])
+            url_style = create_url_style_for_task(task, editor_url_scheme)
+            task_branch = module_branch.add(
+                Text(f"{TASK_ICON}<Function {reduced_task_name}>", style=url_style)
+            )
+
+            if show_nodes:
+                for node in sorted(task.depends_on.values(), key=lambda x: x.path):
+                    reduced_node_name = relative_to(node.path, common_ancestor)
+                    url_style = create_url_style_for_path(node.path, editor_url_scheme)
+                    task_branch.add(
+                        Text(
+                            f"{FILE_ICON}<Dependency {reduced_node_name}>",
+                            style=url_style,
+                        )
+                    )
+
+                for node in sorted(task.produces.values(), key=lambda x: x.path):
+                    reduced_node_name = relative_to(node.path, common_ancestor)
+                    url_style = create_url_style_for_path(node.path, editor_url_scheme)
+                    task_branch.add(
+                        Text(
+                            f"{FILE_ICON}<Product {reduced_node_name}>", style=url_style
+                        )
+                    )
 
     console.print(tree)

--- a/src/_pytask/compat.py
+++ b/src/_pytask/compat.py
@@ -20,6 +20,7 @@ where these two names are different."""
 
 
 def _get_version(module: types.ModuleType) -> str:
+    """Get version from a package."""
     version = getattr(module, "__version__", None)
     if version is None:
         raise ImportError(f"Can't determine version for {module.__name__}")
@@ -119,6 +120,7 @@ def check_for_optional_program(
     errors: str = "raise",
     caller: str = "pytask",
 ) -> Optional[bool]:
+    """Check whether an optional program exists."""
     if errors not in ("warn", "raise", "ignore"):
         raise ValueError(
             f"'errors' must be one of 'warn', 'raise' or 'ignore' and not '{errors}'."

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -9,8 +9,10 @@ from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import TYPE_CHECKING
+from typing import Union
 
 from rich.console import Console
+from rich.style import Style
 from rich.theme import Theme
 from rich.tree import Tree
 
@@ -83,7 +85,7 @@ def escape_squared_brackets(string: str) -> str:
     return string.replace("[", "\\[")
 
 
-def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> str:
+def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> Style:
     """Create the style to add a link to a task id."""
     url_scheme = _EDITOR_URL_SCHEMES.get(edtior_url_scheme, edtior_url_scheme)
 
@@ -92,7 +94,7 @@ def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> str:
         "line_number": inspect.getsourcelines(task.function)[1],
     }
 
-    return "" if not url_scheme else "link " + url_scheme.format(**info)
+    return Style() if not url_scheme else Style(link=url_scheme.format(**info))
 
 
 def _get_file(function: Callable[..., Any]) -> Path:
@@ -101,3 +103,10 @@ def _get_file(function: Callable[..., Any]) -> Path:
         return _get_file(function.func)
     else:
         return Path(inspect.getfile(function))
+
+
+def unify_styles(*styles: Union[str, Style]) -> Style:
+    """Unify styles."""
+    return Style.combine(
+        Style.parse(style) if isinstance(style, str) else style for style in styles
+    )

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -97,6 +97,16 @@ def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> Style
     return Style() if not url_scheme else Style(link=url_scheme.format(**info))
 
 
+def create_url_style_for_path(path: Path, edtior_url_scheme: str) -> Style:
+    """Create the style to add a link to a task id."""
+    url_scheme = _EDITOR_URL_SCHEMES.get(edtior_url_scheme, edtior_url_scheme)
+    return (
+        Style()
+        if not url_scheme
+        else Style(link=url_scheme.format(path=path, line_number="1"))
+    )
+
+
 def _get_file(function: Callable[..., Any]) -> Path:
     """Get path to module where the function is defined."""
     if isinstance(function, functools.partial):

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -1,10 +1,23 @@
 """This module contains the code to format output on the command line."""
+import functools
+import inspect
 import os
 import sys
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Dict
 from typing import Iterable
+from typing import TYPE_CHECKING
 
 from rich.console import Console
+from rich.theme import Theme
 from rich.tree import Tree
+
+
+if TYPE_CHECKING:
+    from _pytask.nodes import MetaTask
+
 
 _IS_WSL = "IS_WSL" in os.environ or "WSL_DISTRO_NAME" in os.environ
 _IS_WINDOWS_TERMINAL = "WT_SESSION" in os.environ
@@ -26,7 +39,18 @@ PYTHON_ICON = "" if _IS_LEGACY_WINDOWS else "🐍 "
 TASK_ICON = "" if _IS_LEGACY_WINDOWS else "📝 "
 
 
-console = Console(color_system=_COLOR_SYSTEM)
+_EDITOR_URL_SCHEMES: Dict[str, str] = {
+    "no_link": "",
+    "file": "file:///{path}",
+    "vscode": "vscode://file/{path}:{line_number}",
+    "pycharm": "pycharm://open?file={path}&line={line_number}",
+}
+
+
+theme = Theme({"warning": "yellow"})
+
+
+console = Console(theme=theme, color_system=_COLOR_SYSTEM)
 
 
 def format_strings_as_flat_tree(strings: Iterable[str], title: str, icon: str) -> str:
@@ -57,3 +81,21 @@ def escape_squared_brackets(string: str) -> str:
 
     """
     return string.replace("[", "\\[")
+
+
+def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> str:
+    url_scheme = _EDITOR_URL_SCHEMES.get(edtior_url_scheme, edtior_url_scheme)
+
+    info = {
+        "path": _get_file(task.function),
+        "line_number": inspect.getsourcelines(task.function)[1],
+    }
+
+    return "" if not url_scheme else "link " + url_scheme.format(**info)
+
+
+def _get_file(function: Callable[..., Any]) -> Path:
+    if isinstance(function, functools.partial):
+        return _get_file(function.func)
+    else:
+        return Path(inspect.getfile(function))

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 
 
 _IS_WSL = "IS_WSL" in os.environ or "WSL_DISTRO_NAME" in os.environ
-_IS_WINDOWS_TERMINAL = "WT_SESSION" in os.environ
+IS_WINDOWS_TERMINAL = "WT_SESSION" in os.environ
 _IS_WINDOWS = sys.platform == "win32"
 
 
-if (_IS_WINDOWS or _IS_WSL) and not _IS_WINDOWS_TERMINAL:
+if (_IS_WINDOWS or _IS_WSL) and not IS_WINDOWS_TERMINAL:
     _IS_LEGACY_WINDOWS = True
 else:
     _IS_LEGACY_WINDOWS = False
@@ -84,6 +84,7 @@ def escape_squared_brackets(string: str) -> str:
 
 
 def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> str:
+    """Create the style to add a link to a task id."""
     url_scheme = _EDITOR_URL_SCHEMES.get(edtior_url_scheme, edtior_url_scheme)
 
     info = {
@@ -95,6 +96,7 @@ def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> str:
 
 
 def _get_file(function: Callable[..., Any]) -> Path:
+    """Get path to module where the function is defined."""
     if isinstance(function, functools.partial):
         return _get_file(function.func)
     else:

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -56,12 +56,6 @@ def pytask_extend_command_line_interface(cli: click.Group) -> None:
             ),
             metavar="module_name:class_name",
         ),
-        click.Option(
-            ["--show-locals"],
-            is_flag=True,
-            default=None,
-            help="Show local variables in tracebacks.",
-        ),
     ]
     cli.commands["build"].params.extend(additional_parameters)
 

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -12,8 +12,8 @@ import _pytask
 import click
 import pluggy
 from _pytask.config import hookimpl
-from _pytask.console import _IS_WINDOWS_TERMINAL
 from _pytask.console import console
+from _pytask.console import IS_WINDOWS_TERMINAL
 from _pytask.session import Session
 from _pytask.shared import convert_truthy_or_falsy_to_bool
 from _pytask.shared import get_first_non_none_value
@@ -65,7 +65,7 @@ def pytask_parse_config(
         default="file",
         callback=lambda x: None if x in [None, "none", "None"] else str(x),
     )
-    if config["editor_url_scheme"] not in ["no_link", "file"] and _IS_WINDOWS_TERMINAL:
+    if config["editor_url_scheme"] not in ["no_link", "file"] and IS_WINDOWS_TERMINAL:
         config["editor_url_scheme"] = "file"
         console.print(
             "WARNING: Windows Terminal does not support url schemes to applications, "

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -12,6 +12,7 @@ import _pytask
 import click
 import pluggy
 from _pytask.config import hookimpl
+from _pytask.console import _IS_WINDOWS_TERMINAL
 from _pytask.console import console
 from _pytask.session import Session
 from _pytask.shared import convert_truthy_or_falsy_to_bool
@@ -57,6 +58,21 @@ def pytask_parse_config(
         default=False,
         callback=convert_truthy_or_falsy_to_bool,
     )
+    config["editor_url_scheme"] = get_first_non_none_value(
+        config_from_cli,
+        config_from_file,
+        key="editor_url_scheme",
+        default="file",
+        callback=lambda x: None if x in [None, "none", "None"] else str(x),
+    )
+    if config["editor_url_scheme"] not in ["no_link", "file"] and _IS_WINDOWS_TERMINAL:
+        config["editor_url_scheme"] = "file"
+        console.print(
+            "WARNING: Windows Terminal does not support url schemes to applications, "
+            "yet. See https://github.com/pytask-dev/pytask/issues/171 for more "
+            "information. Resort to file instead.",
+            style="warning",
+        )
 
 
 @hookimpl

--- a/src/_pytask/parameters.py
+++ b/src/_pytask/parameters.py
@@ -34,7 +34,17 @@ _VERBOSE_OPTION = click.Option(
     default=None,
     help="Make pytask verbose (>= 0) or quiet (< 0) [default: 0]",
 )
-"""click.Option: An general ."""
+"""click.Option: An option to control pytask's verbosity."""
+
+
+_EDITOR_URL_SCHEME_OPTION = click.Option(
+    ["--editor-url-scheme"],
+    default=None,
+    help="Use file, vscode, pycharm or a custom url scheme to add URLs to task "
+    "ids to quickly jump to the task definition. Use no_link to disable URLs.  "
+    "[default file]",
+)
+"""click.Option: An option to embed URLs in task ids."""
 
 
 @hookimpl(trylast=True)
@@ -43,7 +53,7 @@ def pytask_extend_command_line_interface(cli: click.Group) -> None:
     for command in ["build", "clean", "collect", "markers", "profile"]:
         cli.commands[command].params.append(_CONFIG_OPTION)
     for command in ["build", "clean", "collect", "profile"]:
-        cli.commands[command].params.append(_IGNORE_OPTION)
+        cli.commands[command].params.extend([_IGNORE_OPTION, _EDITOR_URL_SCHEME_OPTION])
     for command in ["build", "clean", "collect", "dag", "profile"]:
         cli.commands[command].params.append(_PATH_ARGUMENT)
     for command in ["build"]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import subprocess
 
+import pytest
 from pytask import __version__
 
 
+@pytest.mark.end_to_end
 def test_version_option():
     process = subprocess.run(["pytask", "--version"], capture_output=True)
     assert "pytask, version " + __version__ in process.stdout.decode("utf-8")

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -8,6 +8,7 @@ from _pytask.compat import check_for_optional_program
 from _pytask.compat import import_optional_dependency
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "name, extra, errors, caller, expectation, expected",
     [
@@ -73,6 +74,7 @@ def test_check_for_optional_program(name, extra, errors, caller, expectation, ex
         assert program_exists is expected
 
 
+@pytest.mark.unit
 def test_import_optional():
     match = "pytask requires .*notapackage.* pip .* conda .* 'notapackage'"
     with pytest.raises(ImportError, match=match) as exc_info:
@@ -84,11 +86,13 @@ def test_import_optional():
     assert result is None
 
 
+@pytest.mark.unit
 def test_pony_version_fallback():
     pytest.importorskip("pony")
     import_optional_dependency("pony")
 
 
+@pytest.mark.unit
 def test_bad_version(monkeypatch):
     name = "fakemodule"
     module = types.ModuleType(name)
@@ -113,6 +117,7 @@ def test_bad_version(monkeypatch):
     assert result is module
 
 
+@pytest.mark.unit
 def test_submodule(monkeypatch):
     # Create a fake module with a submodule
     name = "fakemodule"
@@ -138,6 +143,7 @@ def test_submodule(monkeypatch):
     assert result is submodule
 
 
+@pytest.mark.unit
 def test_no_version_raises(monkeypatch):
     name = "fakemodule"
     module = types.ModuleType(name)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import attr
 import pytest
+from _pytask.console import create_url_style_for_path
 from _pytask.console import create_url_style_for_task
 from _pytask.nodes import MetaTask
 from rich.style import Style
@@ -29,6 +30,7 @@ class DummyTask(MetaTask):
 _SOURCE_LINE_TASK_FUNC = inspect.getsourcelines(task_func)[1]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "edtior_url_scheme, expected",
     [
@@ -46,4 +48,24 @@ def test_create_url_style_for_task(edtior_url_scheme, expected):
     path = Path(__file__)
     task = DummyTask(task_func)
     style = create_url_style_for_task(task, edtior_url_scheme)
+    assert style == Style.parse(expected.format(path=path))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "edtior_url_scheme, expected",
+    [
+        ("no_link", ""),
+        ("file", "link file:///{path}"),
+        ("vscode", "link vscode://file/{path}:1"),
+        ("pycharm", "link pycharm://open?file={path}&line=1"),
+        (
+            "editor://module={path}&line_number=1",
+            "link editor://module={path}&line_number=1",
+        ),
+    ],
+)
+def test_create_url_style_for_path(edtior_url_scheme, expected):
+    path = Path(__file__)
+    style = create_url_style_for_path(path, edtior_url_scheme)
     assert style == Style.parse(expected.format(path=path))

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -5,6 +5,7 @@ import attr
 import pytest
 from _pytask.console import create_url_style_for_task
 from _pytask.nodes import MetaTask
+from rich.style import Style
 
 
 def task_func():
@@ -36,9 +37,8 @@ _SOURCE_LINE_TASK_FUNC = inspect.getsourcelines(task_func)[1]
         ("vscode", f"link vscode://file/{{path}}:{_SOURCE_LINE_TASK_FUNC}"),
         ("pycharm", f"link pycharm://open?file={{path}}&line={_SOURCE_LINE_TASK_FUNC}"),
         (
-            f"imaginary-editor://module={{path}}&line_number={_SOURCE_LINE_TASK_FUNC}",
-            "link imaginary-editor://module={{path}}&"
-            f"line_number={_SOURCE_LINE_TASK_FUNC}",
+            f"editor://module={{path}}&line_number={_SOURCE_LINE_TASK_FUNC}",
+            f"link editor://module={{path}}&line_number={_SOURCE_LINE_TASK_FUNC}",
         ),
     ],
 )
@@ -46,4 +46,4 @@ def test_create_url_style_for_task(edtior_url_scheme, expected):
     path = Path(__file__)
     task = DummyTask(task_func)
     style = create_url_style_for_task(task, edtior_url_scheme)
-    assert style == expected.format(path=path)
+    assert style == Style.parse(expected.format(path=path))

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,49 @@
+import inspect
+from pathlib import Path
+
+import attr
+import pytest
+from _pytask.console import create_url_style_for_task
+from _pytask.nodes import MetaTask
+
+
+def task_func():
+    ...
+
+
+@attr.s
+class DummyTask(MetaTask):
+    function = attr.ib()
+
+    def state():
+        ...
+
+    def execute():
+        ...
+
+    def add_report_section():
+        ...
+
+
+_SOURCE_LINE_TASK_FUNC = inspect.getsourcelines(task_func)[1]
+
+
+@pytest.mark.parametrize(
+    "edtior_url_scheme, expected",
+    [
+        ("no_link", ""),
+        ("file", "link file:///{path}"),
+        ("vscode", f"link vscode://file/{{path}}:{_SOURCE_LINE_TASK_FUNC}"),
+        ("pycharm", f"link pycharm://open?file={{path}}&line={_SOURCE_LINE_TASK_FUNC}"),
+        (
+            f"imaginary-editor://module={{path}}&line_number={_SOURCE_LINE_TASK_FUNC}",
+            "link imaginary-editor://module={{path}}&"
+            f"line_number={_SOURCE_LINE_TASK_FUNC}",
+        ),
+    ],
+)
+def test_create_url_style_for_task(edtior_url_scheme, expected):
+    path = Path(__file__)
+    task = DummyTask(task_func)
+    style = create_url_style_for_task(task, edtior_url_scheme)
+    assert style == expected.format(path=path)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -28,6 +28,7 @@ _PARAMETRIZED_LAYOUTS = [
 _TEST_FORMATS = ["dot", "pdf", "png", "jpeg", "svg"]
 
 
+@pytest.mark.end_to_end
 @pytest.mark.skipif(not _IS_PYDOT_INSTALLED, reason="pydot is required")
 @pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
@@ -57,6 +58,7 @@ def test_create_graph_via_cli(tmp_path, runner, format_, layout):
     assert tmp_path.joinpath(f"dag.{format_}").exists()
 
 
+@pytest.mark.end_to_end
 @pytest.mark.skipif(not _IS_PYDOT_INSTALLED, reason="pydot is required")
 @pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
@@ -88,6 +90,7 @@ def _raise_exc(exc):
     raise exc
 
 
+@pytest.mark.end_to_end
 def test_raise_error_with_graph_via_cli_missing_optional_dependency(
     monkeypatch, tmp_path, runner
 ):
@@ -117,6 +120,7 @@ def test_raise_error_with_graph_via_cli_missing_optional_dependency(
     assert not tmp_path.joinpath("dag.png").exists()
 
 
+@pytest.mark.end_to_end
 def test_raise_error_with_graph_via_task_missing_optional_dependency(
     monkeypatch, tmp_path, runner
 ):
@@ -147,6 +151,7 @@ def test_raise_error_with_graph_via_task_missing_optional_dependency(
     assert not tmp_path.joinpath("dag.png").exists()
 
 
+@pytest.mark.end_to_end
 def test_raise_error_with_graph_via_cli_missing_optional_program(
     monkeypatch, tmp_path, runner
 ):
@@ -176,6 +181,7 @@ def test_raise_error_with_graph_via_cli_missing_optional_program(
     assert not tmp_path.joinpath("dag.png").exists()
 
 
+@pytest.mark.end_to_end
 def test_raise_error_with_graph_via_task_missing_optional_program(
     monkeypatch, tmp_path, runner
 ):

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -193,6 +193,7 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
         assert "│ ." in captured.out
 
 
+@pytest.mark.end_to_end
 def test_full_execution_table_is_displayed_at_the_end_of_execution(tmp_path, runner):
     source = """
     import pytask

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -59,7 +59,7 @@ def test_verbose_mode_execution(tmp_path, runner, verbose):
 def test_live_execution_sequentially(capsys, tmp_path):
     path = tmp_path.joinpath("task_dummy.py")
     task = PythonFunctionTask(
-        "task_dummy", path.as_posix() + "::task_dummy", path, None
+        "task_dummy", path.as_posix() + "::task_dummy", path, lambda x: x
     )
 
     live_manager = LiveManager()
@@ -112,7 +112,7 @@ def test_live_execution_sequentially(capsys, tmp_path):
 def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, symbol):
     path = tmp_path.joinpath("task_dummy.py")
     task = PythonFunctionTask(
-        "task_dummy", path.as_posix() + "::task_dummy", path, None
+        "task_dummy", path.as_posix() + "::task_dummy", path, lambda x: x
     )
 
     live_manager = LiveManager()
@@ -150,7 +150,7 @@ def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, s
 def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_table):
     path = tmp_path.joinpath("task_dummy.py")
     running_task = PythonFunctionTask(
-        "task_running", path.as_posix() + "::task_running", path, None
+        "task_running", path.as_posix() + "::task_running", path, lambda x: x
     )
 
     live_manager = LiveManager()
@@ -167,7 +167,7 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
     assert " running " in captured.out
 
     completed_task = PythonFunctionTask(
-        "task_completed", path.as_posix() + "::task_completed", path, None
+        "task_completed", path.as_posix() + "::task_completed", path, lambda x: x
     )
     live.update_running_tasks(completed_task)
     report = ExecutionReport(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -88,6 +88,7 @@ def test_logging_of_outcomes(tmp_path, runner):
     assert "1 failed" in result.output
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "amount, unit, short_label, expectation, expected",
     [

--- a/tests/test_mark_expression.py
+++ b/tests/test_mark_expression.py
@@ -186,6 +186,7 @@ def test_invalid_idents(ident: str) -> None:
         evaluate(ident, lambda ident: True)  # noqa: U100
 
 
+@pytest.mark.unit
 def test_backslash_not_treated_specially() -> None:
     r"""When generating nodeids, if the source name contains special characters
     like a newline, they are escaped into two characters like \n. Therefore, a

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -96,14 +96,14 @@ def test_instantiation_of_metatask():
 @pytest.mark.unit
 def test_instantiation_of_metanode():
     class Node(MetaNode):
-        pass
+        ...
 
     with pytest.raises(TypeError):
         Node()
 
     class Node(MetaNode):
         def state(self):
-            pass
+            ...
 
     task = Node()
     assert isinstance(task, MetaNode)

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -4,6 +4,7 @@ import pytest
 from pytask import cli
 
 
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("is_hidden", [True, False])
 def test_hide_traceback_from_error_report(runner, tmp_path, is_hidden):
     source = f"""


### PR DESCRIPTION
#### Changes

This PR adds clickable links to all mentions of task ids and module paths to open the files in the default editor or vscode and pycharm where only the latter two provide jumping to the correct line number.