### PR TITLE
Create a summary panel which holds aggregate information about tasks and their status.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -21,7 +21,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`173` replaces ``ColorCode`` with custom rich themes.
 - :gh:`174` restructures loosely defined outcomes to clear ``enum.Enum``.
 - :gh:`176` implements a summary panel which holds aggregate information about the
-  number of success, fails and other status.
+  number of successes, fails and other status.
 
 
 0.1.3 - 2021-11-30

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -20,6 +20,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
   information.
 - :gh:`173` replaces ``ColorCode`` with custom rich themes.
 - :gh:`174` restructures loosely defined outcomes to clear ``enum.Enum``.
+- :gh:`176` implements a summary panel which holds aggregate information about the
+  number of success, fails and other status.
 
 
 0.1.3 - 2021-11-30

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -16,6 +16,7 @@ from typing import Union
 from _pytask.config import hookimpl
 from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.console import console
+from _pytask.console import create_summary_panel
 from _pytask.exceptions import CollectionError
 from _pytask.mark_utils import has_marker
 from _pytask.nodes import create_task_name
@@ -274,11 +275,12 @@ def pytask_collect_log(
     """Log collection."""
     session.collection_end = time.time()
 
-    counts = count_outcomes(reports, CollectionOutcome)
     console.print(f"Collected {len(tasks)} task{'' if len(tasks) == 1 else 's'}.")
 
     failed_reports = [r for r in reports if r.outcome == CollectionOutcome.FAIL]
     if failed_reports:
+        counts = count_outcomes(reports, CollectionOutcome)
+
         console.print()
         console.rule(
             Text("Failures during collection", style=CollectionOutcome.FAIL.style),
@@ -305,10 +307,15 @@ def pytask_collect_log(
 
             console.print()
 
+        panel = create_summary_panel(
+            counts, CollectionOutcome, "Collected errors and tasks"
+        )
+        console.print(panel)
+
         session.hook.pytask_log_session_footer(
             session=session,
             counts=counts,
-            duration=round(session.collection_end - session.collection_start, 2),
+            duration=session.collection_end - session.collection_start,
             style=CollectionOutcome.FAIL.style
             if counts[CollectionOutcome.FAIL]
             else CollectionOutcome.SUCCESS.style,

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -314,11 +314,10 @@ def pytask_collect_log(
 
         session.hook.pytask_log_session_footer(
             session=session,
-            counts=counts,
             duration=session.collection_end - session.collection_start,
-            style=CollectionOutcome.FAIL.style
+            outcome=CollectionOutcome.FAIL
             if counts[CollectionOutcome.FAIL]
-            else CollectionOutcome.SUCCESS.style,
+            else CollectionOutcome.SUCCESS,
         )
 
         raise CollectionError

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -61,11 +61,14 @@ _EDITOR_URL_SCHEMES: Dict[str, str] = {
 
 theme = Theme(
     {
-        "failed": "red",
+        "failed": "#BF2D2D",
+        "failed.textonly": "#ffffff on #BF2D2D",
         "neutral": "",
-        "skipped": "yellow",
-        "success": "green",
-        "warning": "yellow",
+        "skipped": "#F4C041",
+        "skipped.textonly": "#000000 on #F4C041",
+        "success": "#137C39",
+        "success.textonly": "#ffffff on #137C39",
+        "warning": "#F4C041",
     }
 )
 
@@ -171,9 +174,9 @@ def create_summary_panel(
                 ),
                 Padding(
                     percentage,
-                    style=outcome.style,  # type: ignore[attr-defined]
                     pad=_HORIZONTAL_PADDING,
                 ),
+                style=outcome.style_textonly,  # type: ignore[attr-defined]
             )
 
     panel = Panel(

--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -242,11 +242,8 @@ def pytask_execute_log_end(session: Session, reports: List[ExecutionReport]) -> 
 
     session.hook.pytask_log_session_footer(
         session=session,
-        counts=counts,
         duration=session.execution_end - session.execution_start,
-        style=TaskOutcome.FAIL.style
-        if counts[TaskOutcome.FAIL]
-        else TaskOutcome.SUCCESS.style,
+        outcome=TaskOutcome.FAIL if counts[TaskOutcome.FAIL] else TaskOutcome.SUCCESS,
     )
 
     if counts[TaskOutcome.FAIL]:

--- a/src/_pytask/hookspecs.py
+++ b/src/_pytask/hookspecs.py
@@ -443,9 +443,8 @@ def pytask_log_session_header(session: "Session") -> None:
 @hookspec
 def pytask_log_session_footer(
     session: "Session",
-    counts: Dict[Union["TaskOutcome", "CollectionOutcome"], int],
     duration: float,
-    style: str,
+    outcome: Union["CollectionOutcome", "TaskOutcome"],
 ) -> None:
     """Log session information at the end of a run."""
 

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -117,35 +117,15 @@ def _format_plugin_names_and_versions(
 
 @hookimpl
 def pytask_log_session_footer(
-    counts: Dict[Union[TaskOutcome, CollectionOutcome], int],
     duration: float,
-    style: str,
+    outcome: Union[CollectionOutcome, TaskOutcome],
 ) -> None:
     """Format the footer of the log message."""
-    message = _style_counts(counts)
     formatted_duration = _format_duration(duration)
-    message += Text(f" in {formatted_duration}", style=style)
-
-    console.rule(message, style=style)
-
-
-def _style_counts(counts: Dict[Union[TaskOutcome, CollectionOutcome], int]) -> str:
-    """Style counts.
-
-    Examples
-    --------
-    >>> from _pytask.outcomes import CollectionOutcome
-    >>> _style_counts({CollectionOutcome.SUCCESS: 1, CollectionOutcome.FAIL: 2})
-    <text '1 succeeded, 2 failed' [Span(0, 11, 'success'), Span(13, 21, 'failed')]>
-
-    """
-    message = []
-    for outcome, count in counts.items():
-        if count:
-            message.append(Text(f"{count} {outcome.description}", style=outcome.style))
-    if not message:
-        message = [Text("nothing to report")]
-    return Text(", ").join(message)
+    message = Text(
+        f"{outcome.description} in {formatted_duration}", style=outcome.style
+    )
+    console.rule(message, style=outcome.style)
 
 
 _TIME_UNITS: List["_TimeUnit"] = [

--- a/src/_pytask/outcomes.py
+++ b/src/_pytask/outcomes.py
@@ -130,7 +130,7 @@ class TaskOutcome(Enum):
 
 def count_outcomes(
     reports: Sequence[Union["CollectionReport", "ExecutionReport"]],
-    outcome_enum: Type[Enum],
+    outcome_enum: Union[Type[CollectionOutcome], Type[TaskOutcome]],
 ) -> Dict[Enum, int]:
     """Count how often an outcome occurred.
 

--- a/src/_pytask/outcomes.py
+++ b/src/_pytask/outcomes.py
@@ -41,8 +41,8 @@ class CollectionOutcome(Enum):
     @property
     def description(self) -> str:
         descriptions = {
-            CollectionOutcome.SUCCESS: "succeeded",
-            CollectionOutcome.FAIL: "failed",
+            CollectionOutcome.SUCCESS: "Succeeded",
+            CollectionOutcome.FAIL: "Failed",
         }
         assert len(descriptions) == len(CollectionOutcome)
         return descriptions[self]
@@ -104,12 +104,12 @@ class TaskOutcome(Enum):
     @property
     def description(self) -> str:
         descriptions = {
-            TaskOutcome.SUCCESS: "succeeded",
-            TaskOutcome.PERSISTENCE: "persisted",
-            TaskOutcome.SKIP_UNCHANGED: "skipped because unchanged",
-            TaskOutcome.SKIP: "skipped",
-            TaskOutcome.SKIP_PREVIOUS_FAILED: "skipped because previous failed",
-            TaskOutcome.FAIL: "failed",
+            TaskOutcome.SUCCESS: "Succeeded",
+            TaskOutcome.PERSISTENCE: "Persisted",
+            TaskOutcome.SKIP_UNCHANGED: "Skipped because unchanged",
+            TaskOutcome.SKIP: "Skipped",
+            TaskOutcome.SKIP_PREVIOUS_FAILED: "Skipped because previous failed",
+            TaskOutcome.FAIL: "Failed",
         }
         assert len(descriptions) == len(TaskOutcome)
         return descriptions[self]

--- a/src/_pytask/outcomes.py
+++ b/src/_pytask/outcomes.py
@@ -56,6 +56,15 @@ class CollectionOutcome(Enum):
         assert len(styles) == len(CollectionOutcome)
         return styles[self]
 
+    @property
+    def style_textonly(self) -> str:
+        styles_textonly = {
+            CollectionOutcome.SUCCESS: "success.textonly",
+            CollectionOutcome.FAIL: "failed.textonly",
+        }
+        assert len(styles_textonly) == len(CollectionOutcome)
+        return styles_textonly[self]
+
 
 class TaskOutcome(Enum):
     """Outcomes of tasks.

--- a/src/_pytask/outcomes.py
+++ b/src/_pytask/outcomes.py
@@ -127,6 +127,19 @@ class TaskOutcome(Enum):
         assert len(styles) == len(TaskOutcome)
         return styles[self]
 
+    @property
+    def style_textonly(self) -> str:
+        styles_textonly = {
+            TaskOutcome.SUCCESS: "success.textonly",
+            TaskOutcome.PERSISTENCE: "success.textonly",
+            TaskOutcome.SKIP_UNCHANGED: "success.textonly",
+            TaskOutcome.SKIP: "skipped.textonly",
+            TaskOutcome.SKIP_PREVIOUS_FAILED: "failed.textonly",
+            TaskOutcome.FAIL: "failed.textonly",
+        }
+        assert len(styles_textonly) == len(TaskOutcome)
+        return styles_textonly[self]
+
 
 def count_outcomes(
     reports: Sequence[Union["CollectionReport", "ExecutionReport"]],

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -196,7 +196,7 @@ def test_capturing_unicode(tmp_path, runner, method):
 
     result = runner.invoke(cli, [tmp_path.as_posix(), f"--capture={method}"])
 
-    assert "1 succeeded" in result.output
+    assert "1  Succeeded" in result.output
     assert result.exit_code == 0
 
 
@@ -213,7 +213,7 @@ def test_capturing_bytes_in_utf8_encoding(tmp_path, runner, method):
 
     result = runner.invoke(cli, [tmp_path.as_posix(), f"--capture={method}"])
 
-    assert "1 succeeded" in result.output
+    assert "1  Succeeded" in result.output
     assert result.exit_code == 0
 
 
@@ -266,7 +266,10 @@ def test_capturing_outerr(tmp_path, runner):
         "1",
         "──────────────────────── Captured stderr during call ────────────────────────",
         "2",
-        "─────────── 1 succeeded, 1 failed in 0 seconds ────────",
+        "2  Collected tasks",
+        "1  Succeeded",
+        "1  Failed",
+        "─────────── Failed in 0 seconds ────────",
     ]:
         assert content in result.output
 
@@ -288,7 +291,7 @@ def test_capture_badoutput_issue412(tmp_path, runner):
         "task_func",
         "assert 0",
         "Captured",
-        "1 failed",
+        "1  Failed",
     ]:
         assert content in result.output
 
@@ -737,7 +740,7 @@ class TestStdCaptureFDinvalidFD:
 
         result = runner.invoke(cli, [tmp_path.as_posix(), "--capture=fd"])
         assert result.exit_code == 0
-        assert "3 succeeded" in result.output
+        assert "3  Succeeded" in result.output
 
     def test_fdcapture_invalid_fd_with_fd_reuse(self, tmp_path):
         os.chdir(tmp_path)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -89,7 +89,7 @@ def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
 
     captured = capsys.readouterr().out
     assert "───── Summary ────" in captured
-    assert "─┐" in captured
-    assert "└─" in captured
+    assert "─┐" in captured or "─╮" in captured
+    assert "└─" in captured or "╰─" in captured
     assert outcome.description in captured
     assert "description" in captured

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -3,9 +3,13 @@ from pathlib import Path
 
 import attr
 import pytest
+from _pytask.console import console
+from _pytask.console import create_summary_panel
 from _pytask.console import create_url_style_for_path
 from _pytask.console import create_url_style_for_task
 from _pytask.nodes import MetaTask
+from _pytask.outcomes import CollectionOutcome
+from _pytask.outcomes import TaskOutcome
 from rich.style import Style
 
 
@@ -69,3 +73,23 @@ def test_create_url_style_for_path(edtior_url_scheme, expected):
     path = Path(__file__)
     style = create_url_style_for_path(path, edtior_url_scheme)
     assert style == Style.parse(expected.format(path=path))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "outcome, outcome_enum, total_description",
+    [(outcome, TaskOutcome, "description") for outcome in TaskOutcome]
+    + [(outcome, CollectionOutcome, "description") for outcome in CollectionOutcome],
+)
+def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
+    counts = {out: 0 for out in outcome_enum}
+    counts[outcome] = 1
+    panel = create_summary_panel(counts, outcome_enum, total_description)
+    console.print(panel)
+
+    captured = capsys.readouterr().out
+    assert "───── Summary ────" in captured
+    assert "─┐" in captured
+    assert "└─" in captured
+    assert outcome.description in captured
+    assert "description" in captured

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -306,7 +306,7 @@ def test_pdb_interaction_capturing_twice(tmp_path):
     assert "Captured stdout during call" in rest
     assert "hello17" in rest  # out is captured
     assert "hello18" in rest  # out is captured
-    assert "1 failed" in rest
+    assert "1  Failed" in rest
     _flush(child)
 
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,9 +1,12 @@
+# -*- coding: <encoding-name> -*-
 import re
 import subprocess
 import textwrap
 
 import pytest
+from _pytask.console import console
 from _pytask.exceptions import NodeNotFoundError
+from _pytask.execute import _create_summary_panel
 from _pytask.outcomes import TaskOutcome
 from pytask import cli
 from pytask import main
@@ -307,3 +310,18 @@ def test_show_errors_immediately(runner, tmp_path, show_errors_immediately):
         assert len(matches_traceback) == 2
     else:
         assert len(matches_traceback) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("outcome", TaskOutcome)
+def test_create_summary_panel(capsys, outcome):
+    counts = {out: 0 for out in TaskOutcome}
+    counts[outcome] = 1
+    panel = _create_summary_panel(counts)
+    console.print(panel)
+
+    captured = capsys.readouterr().out
+    assert "───── Summary ────" in captured
+    assert "─┐" in captured
+    # assert "└─" in captured
+    assert outcome.description in captured

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,12 +1,9 @@
-# -*- coding: <encoding-name> -*-
 import re
 import subprocess
 import textwrap
 
 import pytest
-from _pytask.console import console
 from _pytask.exceptions import NodeNotFoundError
-from _pytask.execute import _create_summary_panel
 from _pytask.outcomes import TaskOutcome
 from pytask import cli
 from pytask import main
@@ -310,18 +307,3 @@ def test_show_errors_immediately(runner, tmp_path, show_errors_immediately):
         assert len(matches_traceback) == 2
     else:
         assert len(matches_traceback) == 1
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("outcome", TaskOutcome)
-def test_create_summary_panel(capsys, outcome):
-    counts = {out: 0 for out in TaskOutcome}
-    counts[outcome] = 1
-    panel = _create_summary_panel(counts)
-    console.print(panel)
-
-    captured = capsys.readouterr().out
-    assert "───── Summary ────" in captured
-    assert "─┐" in captured
-    # assert "└─" in captured
-    assert outcome.description in captured

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -52,7 +52,6 @@ def test_verbose_mode_execution(tmp_path, runner, verbose):
 
     assert ("Task" in result.output) is verbose
     assert ("Outcome" in result.output) is verbose
-    assert ("└──" in result.output) is verbose
     assert ("task_dummy.py::task_dummy" in result.output) is verbose
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -30,36 +30,32 @@ def test_format_plugin_names_and_versions(plugins, expected):
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "infos, duration, color, expected",
+    "duration, outcome, expected",
     [
         (
-            {TaskOutcome.SUCCESS: 1, TaskOutcome.FAIL: 1},
             1,
-            TaskOutcome.FAIL.style,
-            "────── 1 succeeded, 1 failed in 1 second ───────────",
+            TaskOutcome.FAIL,
+            "────── Failed in 1 second ───────────",
         ),
         (
-            {TaskOutcome.SUCCESS: 1, TaskOutcome.SKIP_PREVIOUS_FAILED: 1},
             10,
-            TaskOutcome.SUCCESS.style,
-            "────── 1 succeeded, 1 skipped because previous failed in 10 seconds ─────",
+            TaskOutcome.SUCCESS,
+            "────── Succeeded in 10 seconds ─────",
         ),
         (
-            {TaskOutcome.SKIP_UNCHANGED: 1, TaskOutcome.PERSISTENCE: 1},
             5401,
-            TaskOutcome.SUCCESS.style,
-            "─ 1 skipped because unchanged, 1 persisted in 1 hour, 30 minutes ─",
+            TaskOutcome.SUCCESS,
+            "─ Succeeded in 1 hour, 30 minutes ─",
         ),
         (
-            {TaskOutcome.FAIL: 1, TaskOutcome.SKIP: 1},
             125_000,
-            TaskOutcome.FAIL.style,
-            "─────── 1 failed, 1 skipped in 1 day, 10 hours, 43 minutes ───────────",
+            TaskOutcome.FAIL,
+            "─────── Failed in 1 day, 10 hours, 43 minutes ───────────",
         ),
     ],
 )
-def test_pytask_log_session_footer(capsys, infos, duration, color, expected):
-    pytask_log_session_footer(infos, duration, color)
+def test_pytask_log_session_footer(capsys, duration, outcome, expected):
+    pytask_log_session_footer(duration, outcome)
     captured = capsys.readouterr()
     assert expected in captured.out
 
@@ -68,24 +64,24 @@ def test_pytask_log_session_footer(capsys, infos, duration, color, expected):
 @pytest.mark.parametrize(
     "func, expected_1, expected_2",
     [
-        ("def task_func(): pass", "1 succeeded", "1 skipped because unchanged"),
+        ("def task_func(): pass", "1  Succeeded", "1  Skipped because unchanged"),
         (
             "@pytask.mark.persist\n    def task_func(): pass",
-            "1 persisted",
-            "1 skipped because unchanged",
+            "1  Persisted",
+            "1  Skipped because unchanged",
         ),
-        ("@pytask.mark.skip\n    def task_func(): pass", "1 skipped", "1 skipped"),
+        ("@pytask.mark.skip\n    def task_func(): pass", "1  Skipped", "1  Skipped"),
         (
             "@pytask.mark.skip_unchanged\n    def task_func(): pass",
-            "1 skipped because unchanged",
-            "1 skipped because unchanged",
+            "1  Skipped because unchanged",
+            "1  Skipped because unchanged",
         ),
         (
             "@pytask.mark.skip_ancestor_failed\n    def task_func(): pass",
-            "1 skipped because previous failed",
-            "1 skipped because previous failed",
+            "1  Skipped because previous failed",
+            "1  Skipped because previous failed",
         ),
-        ("def task_func(): raise Exception", "1 failed", "1 failed"),
+        ("def task_func(): raise Exception", "1  Failed", "1  Failed"),
     ],
 )
 def test_logging_of_outcomes(tmp_path, runner, func, expected_1, expected_2):

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -304,7 +304,7 @@ def test_selecting_task_with_keyword_should_run_predecessor(runner, tmp_path):
     result = runner.invoke(cli, [tmp_path.as_posix(), "-k", "second"])
 
     assert result.exit_code == 0
-    assert "2 succeeded" in result.output
+    assert "2  Succeeded" in result.output
 
 
 @pytest.mark.end_to_end
@@ -326,7 +326,7 @@ def test_selecting_task_with_marker_should_run_predecessor(runner, tmp_path):
     result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 
     assert result.exit_code == 0
-    assert "2 succeeded" in result.output
+    assert "2  Succeeded" in result.output
 
 
 @pytest.mark.end_to_end
@@ -346,8 +346,8 @@ def test_selecting_task_with_keyword_ignores_other_task(runner, tmp_path):
     result = runner.invoke(cli, [tmp_path.as_posix(), "-k", "second"])
 
     assert result.exit_code == 0
-    assert "1 succeeded" in result.output
-    assert "1 skipped" in result.output
+    assert "1  Succeeded" in result.output
+    assert "1  Skipped" in result.output
 
 
 @pytest.mark.end_to_end
@@ -368,5 +368,5 @@ def test_selecting_task_with_marker_ignores_other_task(runner, tmp_path):
     result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 
     assert result.exit_code == 0
-    assert "1 succeeded" in result.output
-    assert "1 skipped" in result.output
+    assert "1  Succeeded" in result.output
+    assert "1  Skipped" in result.output


### PR DESCRIPTION
Moves information on successes and failures from the footer of a pytask session to its own panel.

During the collection:
![image](https://user-images.githubusercontent.com/22533006/147785937-5ec7c1b3-b56f-4f79-ad70-1fa7f32b77e1.png)

During the execution:
![image](https://user-images.githubusercontent.com/22533006/147785830-df1ccbf7-3f4e-49bd-8563-2f2be0c6c43d.png)
