### PR TITLE
Shorten and colorize task ids.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
@@ -90,10 +90,9 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/guilatrova/tryceratops
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
     -   id: tryceratops
-        exclude: (console\.py|test_mark_expression\.py)
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.930'
     hooks:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,5 @@ exclude *.yaml
 exclude *.yml
 exclude tox.ini
 
-prune .conda
 prune docs
 prune tests

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -22,7 +22,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`174` restructures loosely defined outcomes to clear ``enum.Enum``.
 - :gh:`176` and :gh:`177` implement a summary panel which holds aggregate information
   about the number of successes, fails and other status.
-- :gh:`178` reduces tasks ids even more and dims the path part.
+- :gh:`178` makes some stylistic changes like reducing tasks ids even more and dims the
+  path part.
 
 
 0.1.3 - 2021-11-30

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -22,6 +22,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`174` restructures loosely defined outcomes to clear ``enum.Enum``.
 - :gh:`176` and :gh:`177` implement a summary panel which holds aggregate information
   about the number of successes, fails and other status.
+- :gh:`178` reduces tasks ids even more and dims the path part.
 
 
 0.1.3 - 2021-11-30

--- a/docs/source/tutorials/how_to_collect_tasks.rst
+++ b/docs/source/tutorials/how_to_collect_tasks.rst
@@ -8,7 +8,7 @@ For example, let us take the following task
 
 .. code-block:: python
 
-    # Content of task_dummy.py
+    # Content of task_module.py
 
     import pytask
 
@@ -29,7 +29,7 @@ Now, running :program:`pytask collect` will produce the following output.
     Root: xxx
     Collected 1 task(s).
 
-    <Module /.../task_dummy.py>
+    <Module /.../task_module.py>
       <Function task_write_file>
 
     ========================================================================
@@ -45,7 +45,7 @@ append the ``--nodes`` flag.
     Root: xxx
     Collected 1 task(s).
 
-    <Module /.../task_dummy.py>
+    <Module /.../task_module.py>
       <Function task_write_file>
         <Dependency /.../in.txt>
         <Product /.../out.txt>

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -84,6 +84,7 @@ def pytask_ignore_collect(path: Path, config: Dict[str, Any]) -> bool:
 def pytask_collect_file_protocol(
     session: Session, path: Path, reports: List[CollectionReport]
 ) -> List[CollectionReport]:
+    """Wrap the collection of tasks from a file to collect reports."""
     try:
         reports = session.hook.pytask_collect_file(
             session=session, path=path, reports=reports

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -21,6 +21,8 @@ from _pytask.exceptions import CollectionError
 from _pytask.mark_utils import has_marker
 from _pytask.nodes import create_task_name
 from _pytask.nodes import FilePathNode
+from _pytask.nodes import find_duplicates
+from _pytask.nodes import MetaTask
 from _pytask.nodes import PythonFunctionTask
 from _pytask.outcomes import CollectionOutcome
 from _pytask.outcomes import count_outcomes
@@ -266,6 +268,52 @@ def _not_ignored_paths(
                 yield from _not_ignored_paths(files_in_dir, session)
             else:
                 yield path
+
+
+@hookimpl(trylast=True)
+def pytask_collect_modify_tasks(tasks: List[MetaTask]) -> None:
+    """Given all tasks, assign a short uniquely identifiable name to each task.
+
+    The shorter ids are necessary to display
+
+    """
+    id_to_short_id = _find_shortest_uniquely_identifiable_name_for_tasks(tasks)
+    for task in tasks:
+        short_id = id_to_short_id[task.name]
+        task.short_name = short_id
+
+
+def _find_shortest_uniquely_identifiable_name_for_tasks(
+    tasks: List[MetaTask],
+) -> Dict[str, str]:
+    """Find the shortest uniquely identifiable name for tasks.
+
+    The shortest unique id consists of the module name plus the base name (e.g. function
+    name) of the task. If this does not make the id unique, append more and more parent
+    folders until the id is unique.
+
+    """
+    id_to_short_id = {}
+
+    # Make attempt to add up to twenty parts of the path to ensure uniqueness.
+    id_to_task = {task.name: task for task in tasks}
+    for n_parts in range(1, 20):
+        dupl_id_to_short_id = {
+            id_: "/".join(task.path.parts[-n_parts:]) + "::" + task.base_name
+            for id_, task in id_to_task.items()
+        }
+        duplicates = find_duplicates(dupl_id_to_short_id.values())
+
+        for id_, short_id in dupl_id_to_short_id.items():
+            if short_id not in duplicates:
+                id_to_short_id[id_] = short_id
+                id_to_task.pop(id_)
+
+    # If there are still non-unique task ids, just use the full id as the short id.
+    for id_, task in id_to_task.items():
+        id_to_short_id[id_] = task.name
+
+    return id_to_short_id
 
 
 @hookimpl

--- a/src/_pytask/collect_command.py
+++ b/src/_pytask/collect_command.py
@@ -11,8 +11,8 @@ import click
 from _pytask.config import hookimpl
 from _pytask.console import console
 from _pytask.console import create_url_style_for_path
-from _pytask.console import create_url_style_for_task
 from _pytask.console import FILE_ICON
+from _pytask.console import format_task_id
 from _pytask.console import PYTHON_ICON
 from _pytask.console import TASK_ICON
 from _pytask.enums import ExitCode
@@ -25,7 +25,6 @@ from _pytask.path import find_common_ancestor
 from _pytask.path import relative_to
 from _pytask.pluginmanager import get_plugin_manager
 from _pytask.session import Session
-from _pytask.shared import reduce_node_name
 from rich.text import Text
 from rich.tree import Tree
 
@@ -194,15 +193,11 @@ def _print_collected_tasks(
         )
 
         for task in tasks:
-            reduced_task_name = reduce_node_name(task, [common_ancestor])
-            url_style = create_url_style_for_task(task, editor_url_scheme)
+            reduced_task_name = format_task_id(
+                task, editor_url_scheme=editor_url_scheme, relative_to=common_ancestor
+            )
             task_branch = module_branch.add(
-                Text.assemble(
-                    TASK_ICON,
-                    "<Function ",
-                    Text(reduced_task_name, style=url_style),
-                    ">",
-                ),
+                Text.assemble(TASK_ICON, "<Function ", reduced_task_name, ">"),
             )
 
             if show_nodes:

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -112,7 +112,7 @@ def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> Style
 
     info = {
         "path": _get_file(task.function),
-        "line_number": inspect.getsourcelines(task.function)[1],
+        "line_number": _get_source_lines(task.function),
     }
 
     return Style() if not url_scheme else Style(link=url_scheme.format(**info))
@@ -134,6 +134,14 @@ def _get_file(function: Callable[..., Any]) -> Path:
         return _get_file(function.func)
     else:
         return Path(inspect.getfile(function))
+
+
+def _get_source_lines(function: Callable[..., Any]) -> int:
+    """Get the source line number of the function."""
+    if isinstance(function, functools.partial):
+        return _get_source_lines(function.func)
+    else:
+        return inspect.getsourcelines(function)[1]
 
 
 def unify_styles(*styles: Union[str, Style]) -> Style:

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -44,7 +44,7 @@ else:
     _IS_LEGACY_WINDOWS = False
 
 
-_COLOR_SYSTEM = None if _IS_LEGACY_WINDOWS else "auto"
+_COLOR_SYSTEM = None if _IS_LEGACY_WINDOWS or "CI" in os.environ else "auto"
 
 
 _HORIZONTAL_PADDING = (0, 1, 0, 1)

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -16,7 +16,6 @@ from typing import Union
 
 import rich
 from rich.console import Console
-from rich.markup import escape
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.segment import Segment
@@ -121,7 +120,7 @@ def format_task_id(task: "MetaTask", editor_url_scheme: str, short_name: bool) -
         path, task_name = task.name.split("::")
     url_style = create_url_style_for_task(task, editor_url_scheme)
     task_id = Text.assemble(
-        Text(path + "::", style="dim"), Text(escape(task_name), style=url_style)
+        Text(path + "::", style="dim"), Text(task_name, style=url_style)
     )
     return task_id
 

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -16,6 +16,7 @@ from typing import Union
 
 import rich
 from rich.console import Console
+from rich.markup import escape
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.segment import Segment
@@ -81,7 +82,12 @@ console = Console(theme=theme, color_system=_COLOR_SYSTEM)
 
 
 def render_to_string(text: Union[str, Text], console: Optional[Console] = None) -> str:
-    """Render text with rich to string including ANSI codes, etc.."""
+    """Render text with rich to string including ANSI codes, etc..
+
+    This function allows to render text with is not automatically printed with rich. For
+    example, render warnings with colors or text in exceptions.
+
+    """
     if console is None:
         console = rich.get_console()
 
@@ -107,16 +113,25 @@ def render_to_string(text: Union[str, Text], console: Optional[Console] = None) 
     return rendered
 
 
+def format_task_id(task: "MetaTask", editor_url_scheme: str, short_name: bool) -> Text:
+    """Format a task id."""
+    if short_name:
+        path, task_name = task.short_name.split("::")
+    else:
+        path, task_name = task.name.split("::")
+    url_style = create_url_style_for_task(task, editor_url_scheme)
+    task_id = Text.assemble(
+        Text(path + "::", style="dim"), Text(escape(task_name), style=url_style)
+    )
+    return task_id
+
+
 def format_strings_as_flat_tree(strings: Iterable[str], title: str, icon: str) -> str:
     """Format list of strings as flat tree."""
     tree = Tree(title)
     for name in strings:
         tree.add(icon + name)
-
-    text = "".join(
-        [x.text for x in tree.__rich_console__(console, console.options)][:-1]
-    )
-
+    text = render_to_string(tree, console)
     return text
 
 

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from typing import Union
 
 import rich
+from _pytask.path import relative_to as relative_to_
 from rich.console import Console
 from rich.padding import Padding
 from rich.panel import Panel
@@ -112,10 +113,18 @@ def render_to_string(text: Union[str, Text], console: Optional[Console] = None) 
     return rendered
 
 
-def format_task_id(task: "MetaTask", editor_url_scheme: str, short_name: bool) -> Text:
+def format_task_id(
+    task: "MetaTask",
+    editor_url_scheme: str,
+    short_name: bool = False,
+    relative_to: Optional[Path] = None,
+) -> Text:
     """Format a task id."""
     if short_name:
         path, task_name = task.short_name.split("::")
+    elif relative_to:
+        path = relative_to_(task.path, relative_to).as_posix()
+        task_name = task.base_name
     else:
         path, task_name = task.name.split("::")
     url_style = create_url_style_for_task(task, editor_url_scheme)

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -9,15 +9,19 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
+from typing import Optional
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
+import rich
 from rich.console import Console
 from rich.padding import Padding
 from rich.panel import Panel
+from rich.segment import Segment
 from rich.style import Style
 from rich.table import Table
+from rich.text import Text
 from rich.theme import Theme
 from rich.tree import Tree
 
@@ -74,6 +78,33 @@ theme = Theme(
 
 
 console = Console(theme=theme, color_system=_COLOR_SYSTEM)
+
+
+def render_to_string(text: Union[str, Text], console: Optional[Console] = None) -> str:
+    """Render text with rich to string including ANSI codes, etc.."""
+    if console is None:
+        console = rich.get_console()
+
+    segments = console.render(text)
+
+    output = []
+    if console.no_color and console._color_system:
+        segments = Segment.remove_color(segments)
+
+    for segment in segments:
+        if segment.style:
+            output.append(
+                segment.style.render(
+                    segment.text,
+                    color_system=console._color_system,
+                    legacy_windows=console.legacy_windows,
+                )
+            )
+        else:
+            output.append(segment.text)
+
+    rendered = "".join(output)
+    return rendered
 
 
 def format_strings_as_flat_tree(strings: Iterable[str], title: str, icon: str) -> str:

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -44,7 +44,7 @@ else:
     _IS_LEGACY_WINDOWS = False
 
 
-_COLOR_SYSTEM = None if _IS_LEGACY_WINDOWS or "CI" in os.environ else "auto"
+_COLOR_SYSTEM = None if _IS_LEGACY_WINDOWS else "auto"
 
 
 _HORIZONTAL_PADDING = (0, 1, 0, 1)

--- a/src/_pytask/console.py
+++ b/src/_pytask/console.py
@@ -89,23 +89,6 @@ def format_strings_as_flat_tree(strings: Iterable[str], title: str, icon: str) -
     return text
 
 
-def escape_squared_brackets(string: str) -> str:
-    """Escape squared brackets which would be accidentally parsed by rich.
-
-    An example are the ids of parametrized tasks which are suffixed with squared
-    brackets surrounding string representations of the parametrized arguments.
-
-    Example
-    -------
-    >>> escape_squared_brackets("Hello!")
-    'Hello!'
-    >>> escape_squared_brackets("task_dummy[arg1-arg2]")
-    'task_dummy\\\\[arg1-arg2]'
-
-    """
-    return string.replace("[", "\\[")
-
-
 def create_url_style_for_task(task: "MetaTask", edtior_url_scheme: str) -> Style:
     """Create the style to add a link to a task id."""
     url_scheme = _EDITOR_URL_SCHEMES.get(edtior_url_scheme, edtior_url_scheme)

--- a/src/_pytask/dag.py
+++ b/src/_pytask/dag.py
@@ -72,6 +72,7 @@ class TopologicalSorter:
 
     @classmethod
     def from_dag(cls, dag: nx.DiGraph, paths: List[Path] = None) -> "TopologicalSorter":
+        """Instantiate from a DAG."""
         if paths is None:
             paths = []
 

--- a/src/_pytask/database.py
+++ b/src/_pytask/database.py
@@ -134,6 +134,7 @@ def pytask_parse_config(
 
 @hookimpl
 def pytask_post_parse(config: Dict[str, Any]) -> None:
+    """Post-parse the configuration."""
     create_database(**config["database"])
 
 

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -455,6 +455,7 @@ def wrap_function_for_tracing(session: Session, task: MetaTask) -> None:
 
 
 def post_mortem(t: TracebackType) -> None:
+    """Start post-mortem debugging."""
     p = PytaskPDB._init_pdb("post_mortem")
     p.reset()
     p.interaction(None, t)

--- a/src/_pytask/exceptions.py
+++ b/src/_pytask/exceptions.py
@@ -1,3 +1,6 @@
+"""This module contains custom exceptions."""
+
+
 class PytaskError(Exception):
     """Base exception for pytask which should be inherited by all other exceptions."""
 

--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -1,3 +1,4 @@
+"""This module contains hook implementations concerning the execution."""
 import sys
 import time
 from typing import Any
@@ -31,17 +32,12 @@ from rich.text import Text
 
 
 @hookimpl
-def pytask_post_parse(config: Dict[str, Any]) -> None:
-    if config["show_errors_immediately"]:
-        config["pm"].register(ShowErrorsImmediatelyPlugin)
-
-
-@hookimpl
 def pytask_parse_config(
     config: Dict[str, Any],
     config_from_cli: Dict[str, Any],
     config_from_file: Dict[str, Any],
 ) -> None:
+    """Parse the configuration."""
     config["show_errors_immediately"] = get_first_non_none_value(
         config_from_cli,
         config_from_file,
@@ -49,6 +45,13 @@ def pytask_parse_config(
         default=False,
         callback=lambda x: x if x is None else bool(x),
     )
+
+
+@hookimpl
+def pytask_post_parse(config: Dict[str, Any]) -> None:
+    """Adjust the configuration after intermediate values have been parsed."""
+    if config["show_errors_immediately"]:
+        config["pm"].register(ShowErrorsImmediatelyPlugin)
 
 
 @hookimpl
@@ -220,6 +223,7 @@ class ShowErrorsImmediatelyPlugin:
 
 @hookimpl
 def pytask_execute_log_end(session: Session, reports: List[ExecutionReport]) -> bool:
+    """Log information on the execution."""
     session.execution_end = time.time()
 
     counts = count_outcomes(reports, TaskOutcome)

--- a/src/_pytask/graph.py
+++ b/src/_pytask/graph.py
@@ -178,6 +178,7 @@ def build_dag(config_from_cli: Dict[str, Any]) -> nx.DiGraph:
 
 
 def _refine_dag(session: Session) -> nx.DiGraph:
+    """Refine the dag for plotting."""
     dag = _shorten_node_labels(session.dag, session.config["paths"])
     dag = _add_root_node(dag)
     dag = _clean_dag(dag)
@@ -188,6 +189,7 @@ def _refine_dag(session: Session) -> nx.DiGraph:
 
 
 def _create_session(config_from_cli: Dict[str, Any]) -> nx.DiGraph:
+    """Create a session object."""
     try:
         pm = get_plugin_manager()
         from _pytask import cli
@@ -227,6 +229,7 @@ def _create_session(config_from_cli: Dict[str, Any]) -> nx.DiGraph:
 
 
 def _shorten_node_labels(dag: nx.DiGraph, paths: List[Path]) -> nx.DiGraph:
+    """Shorten the node labels in the graph for a better experience."""
     node_names = dag.nodes
     short_names = reduce_names_of_multiple_nodes(node_names, dag, paths)
     old_to_new = dict(zip(node_names, short_names))
@@ -235,6 +238,7 @@ def _shorten_node_labels(dag: nx.DiGraph, paths: List[Path]) -> nx.DiGraph:
 
 
 def _add_root_node(dag: nx.DiGraph) -> nx.DiGraph:
+    """Add a root node to the graph to bind all starting nodes together."""
     tasks_without_predecessor = [
         name
         for name in dag.nodes
@@ -256,6 +260,7 @@ def _clean_dag(dag: nx.DiGraph) -> nx.DiGraph:
 
 
 def _style_dag(dag: nx.DiGraph) -> nx.DiGraph:
+    """Style the DAG."""
     shapes = {name: "hexagon" if "::task_" in name else "box" for name in dag.nodes}
     nx.set_node_attributes(dag, shapes, "shape")
     return dag
@@ -273,6 +278,7 @@ def _escape_node_names_with_colons(dag: nx.DiGraph) -> nx.DiGraph:
 
 
 def _write_graph(dag: nx.DiGraph, path: Path, layout: str) -> None:
+    """Write the graph to disk."""
     path.parent.mkdir(exist_ok=True, parents=True)
     graph = nx.nx_pydot.to_pydot(dag)
     graph.write(path, prog=layout, format=path.suffix[1:])

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -12,7 +12,6 @@ import click
 from _pytask.config import hookimpl
 from _pytask.console import console
 from _pytask.console import create_url_style_for_task
-from _pytask.console import unify_styles
 from _pytask.nodes import MetaTask
 from _pytask.outcomes import CollectionOutcome
 from _pytask.outcomes import TaskOutcome
@@ -177,7 +176,7 @@ class LiveExecution:
 
             table = Table()
             table.add_column("Task", overflow="fold")
-            table.add_column("Outcome", justify="center")
+            table.add_column("Outcome")
             for report in relevant_reports:
                 if (
                     report["outcome"]
@@ -191,18 +190,13 @@ class LiveExecution:
                 ):
                     pass
                 else:
-                    if "::" in report["name"]:
-                        path, base = report["name"].split("::")
-                    else:
-                        path, base = "", report["name"]
+                    path, base = report["name"].split("::")
                     name = Text.assemble(
                         Text(path + "::", style="dim"),
                         Text(
                             base,
-                            style=unify_styles(
-                                create_url_style_for_task(
-                                    report["task"], self._editor_url_scheme
-                                )
+                            style=create_url_style_for_task(
+                                report["task"], self._editor_url_scheme
                             ),
                         ),
                     )

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -11,7 +11,7 @@ import attr
 import click
 from _pytask.config import hookimpl
 from _pytask.console import console
-from _pytask.console import create_url_style_for_task
+from _pytask.console import format_task_id
 from _pytask.nodes import MetaTask
 from _pytask.outcomes import CollectionOutcome
 from _pytask.outcomes import TaskOutcome
@@ -195,18 +195,12 @@ class LiveExecution:
                 ):
                     pass
                 else:
-                    path, base = report["name"].split("::")
-                    name = Text.assemble(
-                        Text(path + "::", style="dim"),
-                        Text(
-                            base,
-                            style=create_url_style_for_task(
-                                report["task"], self._editor_url_scheme
-                            ),
-                        ),
-                    )
                     table.add_row(
-                        name,
+                        format_task_id(
+                            report["task"],
+                            editor_url_scheme=self._editor_url_scheme,
+                            short_name=True,
+                        ),
                         Text(report["outcome"].symbol, style=report["outcome"].style),
                     )
             for running_task in self._running_tasks:

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -135,7 +135,7 @@ class LiveExecution:
     _live_manager = attr.ib(type=LiveManager)
     _n_entries_in_table = attr.ib(type=int)
     _verbose = attr.ib(type=int)
-    _editor_url_scheme = attr.ib(type=str, default="file")
+    _editor_url_scheme = attr.ib(type=str)
     _running_tasks = attr.ib(factory=set, type=Set[str])
     _reports = attr.ib(factory=list, type=List[Dict[str, Any]])
 

--- a/src/_pytask/live.py
+++ b/src/_pytask/live.py
@@ -142,7 +142,7 @@ class LiveExecution:
     def pytask_execute_build(self) -> Generator[None, None, None]:
         self._live_manager.start()
         yield
-        self._update_table(reduce_table=False)
+        self._update_table(reduce_table=False, sort_table=True)
         self._live_manager.stop(transient=False)
 
     @hookimpl(tryfirst=True)
@@ -155,7 +155,7 @@ class LiveExecution:
         self.update_reports(report)
         return True
 
-    def _generate_table(self, reduce_table: bool) -> Optional[Table]:
+    def _generate_table(self, reduce_table: bool, sort_table: bool) -> Optional[Table]:
         """Generate the table.
 
         First, display all completed tasks and, then, all running tasks.
@@ -173,6 +173,11 @@ class LiveExecution:
                 relevant_reports = self._reports[-n_reports_to_display:]
             else:
                 relevant_reports = []
+
+            if sort_table:
+                relevant_reports = sorted(
+                    relevant_reports, key=lambda report: report["name"]
+                )
 
             table = Table()
             table.add_column("Task", overflow="fold")
@@ -211,8 +216,10 @@ class LiveExecution:
 
         return table
 
-    def _update_table(self, reduce_table: bool = True) -> None:
-        table = self._generate_table(reduce_table)
+    def _update_table(
+        self, reduce_table: bool = True, sort_table: bool = False
+    ) -> None:
+        table = self._generate_table(reduce_table=reduce_table, sort_table=sort_table)
         self._live_manager.update(table)
 
     def update_running_tasks(self, new_running_task: MetaTask) -> None:

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -159,7 +159,7 @@ def _humanize_time(
     >>> _humanize_time(173, "hours")
     [(7, 'days'), (5, 'hours')]
     >>> _humanize_time(173.345, "seconds")
-    [(2, 'minutes'), (53, 'seconds')]
+    [(2, 'minutes'), (53.34, 'seconds')]
     >>> _humanize_time(173, "hours", short_label=True)
     [(7, 'd'), (5, 'h')]
     >>> _humanize_time(0, "seconds", short_label=True)

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -151,7 +151,7 @@ def _format_duration(duration: float) -> str:
 
 def _humanize_time(
     amount: Union[int, float], unit: str, short_label: bool = False
-) -> List[Tuple[int, str]]:
+) -> List[Tuple[float, str]]:
     """Humanize the time.
 
     Examples
@@ -180,7 +180,7 @@ def _humanize_time(
 
     seconds = amount * _TIME_UNITS[index]["in_seconds"]
 
-    result = []
+    result: List[Tuple[float, str]] = []
     remaining_seconds = seconds
     for entry in _TIME_UNITS:
         whole_units = int(remaining_seconds / entry["in_seconds"])
@@ -196,7 +196,7 @@ def _humanize_time(
                 result.append((whole_units, label))
                 remaining_seconds -= whole_units * entry["in_seconds"]
             else:
-                result.append((int(remaining_seconds), label))
+                result.append((round(remaining_seconds, 2), label))
 
     if not result:
         result.append(

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -1,6 +1,7 @@
 """Add general logging capabilities."""
 import platform
 import sys
+import warnings
 from typing import Any
 from typing import Dict
 from typing import List
@@ -20,6 +21,7 @@ from _pytask.session import Session
 from _pytask.shared import convert_truthy_or_falsy_to_bool
 from _pytask.shared import get_first_non_none_value
 from rich.text import Text
+
 
 try:
     from pluggy._manager import DistFacade
@@ -70,11 +72,10 @@ def pytask_parse_config(
     )
     if config["editor_url_scheme"] not in ["no_link", "file"] and IS_WINDOWS_TERMINAL:
         config["editor_url_scheme"] = "file"
-        console.print(
-            "WARNING: Windows Terminal does not support url schemes to applications, "
-            "yet. See https://github.com/pytask-dev/pytask/issues/171 for more "
-            "information. Resort to file instead.",
-            style="warning",
+        warnings.warn(
+            "Windows Terminal does not support url schemes to applications, yet."
+            "See https://github.com/pytask-dev/pytask/issues/171 for more information. "
+            "Resort to `editor_url_scheme='file'`."
         )
 
 

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -76,7 +76,8 @@ class MetaTask(MetaNode):
 
     base_name: str
     name: str
-    markers: "List[Mark]"
+    short_name: Optional[str]
+    markers: List["Mark"]
     depends_on: Dict[str, MetaNode]
     produces: Dict[str, MetaNode]
     path: Path
@@ -107,6 +108,8 @@ class PythonFunctionTask(MetaTask):
     """pathlib.Path: Path to the file where the task was defined."""
     function = attr.ib(type=Callable[..., Any])
     """Callable[..., Any]: The task function."""
+    short_name = attr.ib(default=None, type=Optional[str])
+    """str: The shortest uniquely identifiable name for task for display."""
     depends_on = attr.ib(factory=dict, type=Dict[str, MetaNode])
     """Dict[str, MetaNode]: A list of dependencies of task."""
     produces = attr.ib(factory=dict, type=Dict[str, MetaNode])

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -108,7 +108,7 @@ class PythonFunctionTask(MetaTask):
     """pathlib.Path: Path to the file where the task was defined."""
     function = attr.ib(type=Callable[..., Any])
     """Callable[..., Any]: The task function."""
-    short_name = attr.ib(default=None, type=Optional[str])
+    short_name = attr.ib(default=None, type=Optional[str], init=False)
     """str: The shortest uniquely identifiable name for task for display."""
     depends_on = attr.ib(factory=dict, type=Dict[str, MetaNode])
     """Dict[str, MetaNode]: A list of dependencies of task."""
@@ -122,6 +122,10 @@ class PythonFunctionTask(MetaTask):
     """List[Tuple[str, str, str]]: Reports with entries for when, what, and content."""
     attributes = attr.ib(factory=dict, type=Dict[Any, Any])
     """Dict[Any, Any]: A dictionary to store additional information of the task."""
+
+    def __attrs_post_init__(self: "PythonFunctionTask") -> None:
+        if self.short_name is None:
+            self.short_name = self.name
 
     @classmethod
     def from_path_name_function_session(

--- a/src/_pytask/path.py
+++ b/src/_pytask/path.py
@@ -84,6 +84,7 @@ def find_closest_ancestor(
 
 
 def find_common_ancestor_of_nodes(*names: str) -> Path:
+    """Find the common ancestor from task names and nodes."""
     cleaned_names = [name.split("::")[0] for name in names]
     return find_common_ancestor(*cleaned_names)
 

--- a/src/_pytask/profile.py
+++ b/src/_pytask/profile.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import click
 from _pytask.config import hookimpl
 from _pytask.console import console
-from _pytask.console import create_url_style_for_task
+from _pytask.console import format_task_id
 from _pytask.database import db
 from _pytask.enums import ExitCode
 from _pytask.exceptions import CollectionError
@@ -30,11 +30,10 @@ from _pytask.pluginmanager import get_plugin_manager
 from _pytask.report import ExecutionReport
 from _pytask.session import Session
 from _pytask.shared import get_first_non_none_value
-from _pytask.shared import reduce_node_name
 from _pytask.traceback import render_exc_info
 from pony import orm
 from rich.table import Table
-from rich.text import Text
+
 
 if TYPE_CHECKING:
     from typing import NoReturn
@@ -177,12 +176,13 @@ def _print_profile_table(
             table.add_column(name, justify="right")
 
         for task_name, info in profile.items():
-            reduced_name = reduce_node_name(name_to_task[task_name], config["paths"])
-            url = create_url_style_for_task(
-                name_to_task[task_name], config["editor_url_scheme"]
+            task_id = format_task_id(
+                task=name_to_task[task_name],
+                editor_url_scheme=config["editor_url_scheme"],
+                short_name=True,
             )
             infos = [str(i) for i in info.values()]
-            table.add_row(Text(reduced_name, style=url), *infos)
+            table.add_row(task_id, *infos)
 
         console.print(table)
     else:
@@ -197,7 +197,7 @@ class DurationNameSpace:
     ) -> None:
         runtimes = _collect_runtimes([task.name for task in tasks])
         for name, duration in runtimes.items():
-            profile[name]["Last Duration (in s)"] = round(duration, 2)
+            profile[name]["Duration (in s)"] = round(duration, 2)
 
 
 @orm.db_session

--- a/src/_pytask/resolve_dependencies.py
+++ b/src/_pytask/resolve_dependencies.py
@@ -12,6 +12,7 @@ from _pytask.config import IS_FILE_SYSTEM_CASE_SENSITIVE
 from _pytask.console import ARROW_DOWN_ICON
 from _pytask.console import console
 from _pytask.console import FILE_ICON
+from _pytask.console import render_to_string
 from _pytask.console import TASK_ICON
 from _pytask.dag import node_and_neighbors
 from _pytask.dag import task_and_descending_tasks
@@ -260,14 +261,11 @@ def _format_dictionary_to_tree(dict_: Dict[str, List[str]], title: str) -> str:
     tree = Tree(title)
 
     for node, tasks in dict_.items():
-        branch = tree.add(FILE_ICON + node)
+        branch = tree.add(Text.assemble(FILE_ICON, node))
         for task in tasks:
-            branch.add(TASK_ICON + task)
+            branch.add(Text.assemble(TASK_ICON, task))
 
-    text = "".join(
-        [x.text for x in tree.__rich_console__(console, console.options)][:-1]
-    )
-
+    text = render_to_string(tree)
     return text
 
 

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -10,13 +10,13 @@ from typing import Sequence
 from typing import Union
 
 import networkx as nx
-from _pytask.console import escape_squared_brackets
 from _pytask.nodes import create_task_name
 from _pytask.nodes import MetaNode
 from _pytask.nodes import MetaTask
 from _pytask.path import find_closest_ancestor
 from _pytask.path import find_common_ancestor
 from _pytask.path import relative_to
+from rich.markup import escape
 
 
 def to_list(scalar_or_iter: Any) -> List[Any]:
@@ -159,7 +159,7 @@ def reduce_node_name(node: "MetaNode", paths: Sequence[Union[str, Path]]) -> str
     if isinstance(node, MetaTask):
         shortened_path = relative_to(node.path, ancestor)
         raw_name = create_task_name(shortened_path, node.base_name)
-        name = escape_squared_brackets(raw_name)
+        name = escape(raw_name)
     elif isinstance(node, MetaNode):
         name = relative_to(node.path, ancestor).as_posix()
     else:

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -16,7 +16,6 @@ from _pytask.nodes import MetaTask
 from _pytask.path import find_closest_ancestor
 from _pytask.path import find_common_ancestor
 from _pytask.path import relative_to
-from rich.markup import escape
 
 
 def to_list(scalar_or_iter: Any) -> List[Any]:
@@ -158,8 +157,7 @@ def reduce_node_name(node: "MetaNode", paths: Sequence[Union[str, Path]]) -> str
 
     if isinstance(node, MetaTask):
         shortened_path = relative_to(node.path, ancestor)
-        raw_name = create_task_name(shortened_path, node.base_name)
-        name = escape(raw_name)
+        name = create_task_name(shortened_path, node.base_name)
     elif isinstance(node, MetaNode):
         name = relative_to(node.path, ancestor).as_posix()
     else:

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -23,7 +23,7 @@ def to_list(scalar_or_iter: Any) -> List[Any]:
 
     Parameters
     ----------
-    scalar_or_iter : str or list
+    scalar_or_iter : Any
 
     Returns
     -------

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,10 +7,10 @@ from pytask import cli
 @pytest.mark.end_to_end
 def test_execution_failed(runner, tmp_path):
     source = """
-    def task_dummy():
+    def task_raises():
         raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == 1
@@ -27,7 +27,7 @@ def test_collection_failed(runner, tmp_path):
     source = """
     raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == 3
@@ -40,15 +40,15 @@ def test_resolving_dependencies_failed(runner, tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy_1():
+    def task_passes_1():
         pass
 
     @pytask.mark.depends_on("out.txt")
     @pytask.mark.produces("in.txt")
-    def task_dummy_2():
+    def task_passes_2():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == 4

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -226,7 +226,7 @@ def test_collect_capturing(tmp_path, runner):
     sys.stderr.write("collect %s_stderr failure" % 13)
     import xyz42123
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 
@@ -283,7 +283,7 @@ def test_capture_badoutput_issue412(tmp_path, runner):
         os.write(1, omg)
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "--capture=fd"])
 
@@ -387,7 +387,7 @@ def test_captureresult() -> None:
 
 @pytest.fixture()
 def tmpfile(tmp_path) -> Generator[BinaryIO, None, None]:
-    f = tmp_path.joinpath("task_dummy.py").open("wb+")
+    f = tmp_path.joinpath("task_module.py").open("wb+")
     yield f
     if not f.closed:
         f.close()
@@ -430,7 +430,7 @@ class TestFDCapture:
 
     def test_simple_many_check_open_files(self, tmp_path):
         with lsof_check():
-            with tmp_path.joinpath("task_dummy.py").open("wb+") as tmpfile:
+            with tmp_path.joinpath("task_module.py").open("wb+") as tmpfile:
                 self.test_simple_many(tmpfile)
 
     def test_simple_fail_second_start(self, tmpfile):
@@ -664,7 +664,7 @@ class TestStdCaptureFD(TestStdCapture):
             os.write(1, b"hello\\n")
             assert 0
         """
-        tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+        tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
         result = runner.invoke(cli, [tmp_path.as_posix()])
         for content in [
             "task_x",
@@ -736,7 +736,7 @@ class TestStdCaptureFDinvalidFD:
             )
             cap.stop_capturing()
         """
-        tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+        tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
         result = runner.invoke(cli, [tmp_path.as_posix(), "--capture=fd"])
         assert result.exit_code == 0

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -12,10 +12,10 @@ def sample_project_path(tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy(produces):
+    def task_write_text(produces):
         produces.write_text("a")
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").touch()
 
     tmp_path.joinpath("to_be_deleted_file_1.txt").touch()
@@ -161,7 +161,7 @@ def test_collection_failed(runner, tmp_path):
     source = """
     raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, ["clean", tmp_path.as_posix()])
     assert result.exit_code == 3

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -193,7 +193,7 @@ def test_find_shortest_uniquely_identifiable_names_for_tasks(tmp_path):
         tasks.append(
             PythonFunctionTask(base_name, task_id, path_identifiable_by_base_name, None)
         )
-        expected[task_id] = base_name
+        expected[task_id] = "t.py::" + base_name
 
     dir_identifiable_by_module_name = tmp_path.joinpath("identifiable_by_module")
     dir_identifiable_by_module_name.mkdir()

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -22,10 +22,10 @@ def test_collect_filepathnode_with_relative_path(tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy(depends_on, produces):
+    def task_write_text(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("Relative paths work.")
 
     session = main({"paths": tmp_path})
@@ -44,7 +44,7 @@ def test_collect_filepathnode_with_unknown_type(tmp_path):
     def task_with_non_path_dependency():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -69,7 +69,7 @@ def test_collect_nodes_with_the_same_name(runner, tmp_path):
     def task_1(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     tmp_path.joinpath("text.txt").write_text("in root")
 
@@ -84,9 +84,9 @@ def test_collect_nodes_with_the_same_name(runner, tmp_path):
 
 
 @pytest.mark.end_to_end
-@pytest.mark.parametrize("path_extension", ["", "task_dummy.py"])
+@pytest.mark.parametrize("path_extension", ["", "task_module.py"])
 def test_collect_same_test_different_ways(tmp_path, path_extension):
-    tmp_path.joinpath("task_dummy.py").write_text("def task_dummy(): pass")
+    tmp_path.joinpath("task_module.py").write_text("def task_passes(): pass")
 
     session = main({"paths": tmp_path.joinpath(path_extension)})
 
@@ -98,13 +98,13 @@ def test_collect_same_test_different_ways(tmp_path, path_extension):
 @pytest.mark.parametrize(
     "task_files, pattern, expected_collected_tasks",
     [
-        (["dummy_task.py"], "*_task.py", 1),
-        (["tasks_dummy.py"], "tasks_*", 1),
-        (["dummy_tasks.py"], "*_tasks.py", 1),
-        (["task_dummy.py", "tasks_dummy.py"], "None", 1),
-        (["task_dummy.py", "tasks_dummy.py"], "tasks_*.py", 1),
+        (["example_task.py"], "*_task.py", 1),
+        (["tasks_example.py"], "tasks_*", 1),
+        (["example_tasks.py"], "*_tasks.py", 1),
+        (["task_module.py", "tasks_example.py"], "None", 1),
+        (["task_module.py", "tasks_example.py"], "tasks_*.py", 1),
         (
-            ["task_dummy.py", "tasks_dummy.py"],
+            ["task_module.py", "tasks_example.py"],
             "\n            task_*.py\n             tasks_*.py",
             2,
         ),
@@ -117,7 +117,7 @@ def test_collect_files_w_custom_file_name_pattern(
     tmp_path.joinpath(config_name).write_text(f"[pytask]\ntask_files = {pattern}")
 
     for file in task_files:
-        tmp_path.joinpath(file).write_text("def task_dummy(): pass")
+        tmp_path.joinpath(file).write_text("def task_example(): pass")
 
     session = main({"paths": tmp_path})
 

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -17,27 +17,27 @@ def test_collect_task(runner, tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy():
+    def task_example():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").touch()
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy>" in captured
+    assert "task_example>" in captured
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "--nodes"])
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy>" in captured
+    assert "task_example>" in captured
     assert "<Dependency" in captured
     assert "in.txt>" in captured
     assert "<Product" in captured
@@ -51,17 +51,17 @@ def test_collect_parametrized_tasks(runner, tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.parametrize("arg, produces", [(0, "out_0.txt"), (1, "out_1.txt")])
-    def task_dummy(arg):
+    def task_example(arg):
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").touch()
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
 
     captured = result.output.replace("\n", "").replace(" ", "").replace("\u2502", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
     assert "[0-out_0.txt]>" in captured
     assert "[1-out_1.txt]>" in captured
@@ -74,15 +74,15 @@ def test_collect_task_with_expressions(runner, tmp_path):
 
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
-    def task_dummy_1():
+    def task_example_1():
         pass
 
     @pytask.mark.depends_on("in_2.txt")
     @pytask.mark.produces("out_2.txt")
-    def task_dummy_2():
+    def task_example_2():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in_1.txt").touch()
     tmp_path.joinpath("in_2.txt").touch()
 
@@ -90,19 +90,19 @@ def test_collect_task_with_expressions(runner, tmp_path):
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Function" in captured
-    assert "task_dummy_2>" not in captured
+    assert "task_example_2>" not in captured
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "-k", "_1", "--nodes"])
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Dependency" in captured
     assert "in_1.txt>" in captured
     assert "<Product" in captured
@@ -118,15 +118,15 @@ def test_collect_task_with_marker(runner, tmp_path, config_name):
     @pytask.mark.wip
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
-    def task_dummy_1():
+    def task_example_1():
         pass
 
     @pytask.mark.depends_on("in_2.txt")
     @pytask.mark.produces("out_2.txt")
-    def task_dummy_2():
+    def task_example_2():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in_1.txt").touch()
 
     config = """
@@ -140,11 +140,11 @@ def test_collect_task_with_marker(runner, tmp_path, config_name):
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Function" in captured
-    assert "task_dummy_2>" not in captured
+    assert "task_example_2>" not in captured
 
     result = runner.invoke(
         cli, ["collect", tmp_path.as_posix(), "-m", "wip", "--nodes"]
@@ -152,9 +152,9 @@ def test_collect_task_with_marker(runner, tmp_path, config_name):
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy.py>" in captured
+    assert "task_module.py>" in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Dependency" in captured
     assert "in_1.txt>" in captured
     assert "<Product" in captured
@@ -170,23 +170,23 @@ def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
     @pytask.mark.wip
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
-    def task_dummy_1():
+    def task_example_1():
         pass
     """
-    tmp_path.joinpath("task_dummy_1.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_example_1.py").write_text(textwrap.dedent(source))
 
     source = """
     @pytask.mark.depends_on("in_2.txt")
     @pytask.mark.produces("out_2.txt")
-    def task_dummy_2():
+    def task_example_2():
         pass
     """
-    tmp_path.joinpath("task_dummy_2.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_example_2.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in_1.txt").touch()
 
     config = """
     [pytask]
-    ignore = task_dummy_2.py
+    ignore = task_example_2.py
     """
     tmp_path.joinpath(config_name).write_text(textwrap.dedent(config))
 
@@ -194,21 +194,21 @@ def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy_1.py>" in captured
-    assert "task_dummy_2.py>" not in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Function" in captured
-    assert "task_dummy_2>" not in captured
+    assert "task_example_2>" not in captured
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "--nodes"])
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy_1.py>" in captured
-    assert "task_dummy_2.py>" not in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Dependency" in captured
     assert "in_1.txt>" in captured
     assert "<Product" in captured
@@ -223,43 +223,44 @@ def test_collect_task_with_ignore_from_cli(runner, tmp_path):
     @pytask.mark.wip
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
-    def task_dummy_1():
+    def task_example_1():
         pass
     """
-    tmp_path.joinpath("task_dummy_1.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_example_1.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in_1.txt").touch()
 
     source = """
     @pytask.mark.depends_on("in_2.txt")
     @pytask.mark.produces("out_2.txt")
-    def task_dummy_2():
+    def task_example_2():
         pass
     """
-    tmp_path.joinpath("task_dummy_2.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_example_2.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(
-        cli, ["collect", tmp_path.as_posix(), "--ignore", "task_dummy_2.py"]
+        cli, ["collect", tmp_path.as_posix(), "--ignore", "task_example_2.py"]
     )
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy_1.py>" in captured
-    assert "task_dummy_2.py>" not in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Function" in captured
-    assert "task_dummy_2>" not in captured
+    assert "task_example_2>" not in captured
 
     result = runner.invoke(
-        cli, ["collect", tmp_path.as_posix(), "--ignore", "task_dummy_2.py", "--nodes"]
+        cli,
+        ["collect", tmp_path.as_posix(), "--ignore", "task_example_2.py", "--nodes"],
     )
 
     captured = result.output.replace("\n", "").replace(" ", "")
     assert "<Module" in captured
-    assert "task_dummy_1.py>" in captured
-    assert "task_dummy_2.py>" not in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
     assert "<Function" in captured
-    assert "task_dummy_1>" in captured
+    assert "task_example_1>" in captured
     assert "<Dependency" in captured
     assert "in_1.txt>" in captured
     assert "<Product" in captured

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from pytask import main
     [
         ("pytask.ini", ["src/a", "src/b"], ".", "pytask.ini"),
         ("tox.ini", ["."], None, "tox.ini"),
-        (None, ["task_dummy.py"], "", None),
+        (None, ["task_module.py"], "", None),
     ],
 )
 def test_find_project_root_and_ini(
@@ -125,7 +125,7 @@ def test_passing_paths_via_configuration_file(tmp_path, config_path, file_or_fol
     for letter in ["a", "b"]:
         tmp_path.joinpath(f"folder_{letter}").mkdir()
         tmp_path.joinpath(f"folder_{letter}", f"task_{letter}.py").write_text(
-            "def task_dummy(): pass"
+            "def task_passes(): pass"
         )
 
     os.chdir(tmp_path)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -7,9 +7,11 @@ from _pytask.console import console
 from _pytask.console import create_summary_panel
 from _pytask.console import create_url_style_for_path
 from _pytask.console import create_url_style_for_task
+from _pytask.console import render_to_string
 from _pytask.nodes import MetaTask
 from _pytask.outcomes import CollectionOutcome
 from _pytask.outcomes import TaskOutcome
+from rich.console import Console
 from rich.style import Style
 
 
@@ -93,3 +95,17 @@ def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
     assert "└─" in captured or "╰─" in captured
     assert outcome.description in captured
     assert "description" in captured
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "color_system, text, expected",
+    [
+        (None, "[red]text", "text\n"),
+        ("truecolor", "[red]text", "\x1b[31mtext\x1b[0m\n"),
+    ],
+)
+def test_render_to_string(color_system, text, expected):
+    console = Console(color_system=color_system)
+    result = render_to_string(text, console)
+    assert result == expected

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -7,12 +7,17 @@ from _pytask.console import console
 from _pytask.console import create_summary_panel
 from _pytask.console import create_url_style_for_path
 from _pytask.console import create_url_style_for_task
+from _pytask.console import format_task_id
 from _pytask.console import render_to_string
+from _pytask.nodes import create_task_name
 from _pytask.nodes import MetaTask
+from _pytask.nodes import PythonFunctionTask
 from _pytask.outcomes import CollectionOutcome
 from _pytask.outcomes import TaskOutcome
 from rich.console import Console
 from rich.style import Style
+from rich.text import Span
+from rich.text import Text
 
 
 def task_func():
@@ -108,4 +113,65 @@ def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
 def test_render_to_string(color_system, text, expected):
     console = Console(color_system=color_system)
     result = render_to_string(text, console)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "base_name, short_name, editor_url_scheme, use_short_name, relative_to, expected",
+    [
+        pytest.param(
+            "task_a",
+            None,
+            "no_link",
+            False,
+            None,
+            Text(
+                "C:/Users/tobia/git/pytask/tests/test_console.py::task_a",
+                spans=[Span(0, 49, "dim"), Span(49, 55, Style())],
+            ),
+            id="format full id",
+        ),
+        pytest.param(
+            "task_a",
+            "test_console.py::task_a",
+            "no_link",
+            True,
+            None,
+            Text(
+                "test_console.py::task_a",
+                spans=[Span(0, 17, "dim"), Span(17, 23, Style())],
+            ),
+            id="format short id",
+        ),
+        pytest.param(
+            "task_a",
+            None,
+            "no_link",
+            False,
+            Path(__file__).parent,
+            Text(
+                "tests/test_console.py::task_a",
+                spans=[Span(0, 23, "dim"), Span(23, 29, Style())],
+            ),
+            id="format relative to id",
+        ),
+    ],
+)
+def test_format_task_id(
+    base_name,
+    short_name,
+    editor_url_scheme,
+    use_short_name,
+    relative_to,
+    expected,
+):
+    path = Path(__file__)
+
+    task = PythonFunctionTask(
+        base_name, create_task_name(path, base_name), path, task_func
+    )
+    if short_name is not None:
+        task.short_name = short_name
+
+    result = format_task_id(task, editor_url_scheme, use_short_name, relative_to)
     assert result == expected

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -93,3 +93,5 @@ def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
     assert "└─" in captured or "╰─" in captured
     assert outcome.description in captured
     assert "description" in captured
+
+    ...

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -93,5 +93,3 @@ def test_create_summary_panel(capsys, outcome, outcome_enum, total_description):
     assert "└─" in captured or "╰─" in captured
     assert outcome.description in captured
     assert "description" in captured
-
-    ...

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -116,6 +116,9 @@ def test_render_to_string(color_system, text, expected):
     assert result == expected
 
 
+_THIS_FILE = Path(__file__)
+
+
 @pytest.mark.parametrize(
     "base_name, short_name, editor_url_scheme, use_short_name, relative_to, expected",
     [
@@ -126,8 +129,11 @@ def test_render_to_string(color_system, text, expected):
             False,
             None,
             Text(
-                "C:/Users/tobia/git/pytask/tests/test_console.py::task_a",
-                spans=[Span(0, 49, "dim"), Span(49, 55, Style())],
+                _THIS_FILE.as_posix() + "::task_a",
+                spans=[
+                    Span(0, len(_THIS_FILE.as_posix()) + 2, "dim"),
+                    Span(len(_THIS_FILE.as_posix()) + 2, 55, Style()),
+                ],
             ),
             id="format full id",
         ),
@@ -148,7 +154,7 @@ def test_render_to_string(color_system, text, expected):
             None,
             "no_link",
             False,
-            Path(__file__).parent,
+            _THIS_FILE.parent,
             Text(
                 "tests/test_console.py::task_a",
                 spans=[Span(0, 23, "dim"), Span(23, 29, Style())],
@@ -165,7 +171,7 @@ def test_format_task_id(
     relative_to,
     expected,
 ):
-    path = Path(__file__)
+    path = _THIS_FILE
 
     task = PythonFunctionTask(
         base_name, create_task_name(path, base_name), path, task_func

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -132,7 +132,11 @@ _THIS_FILE = Path(__file__)
                 _THIS_FILE.as_posix() + "::task_a",
                 spans=[
                     Span(0, len(_THIS_FILE.as_posix()) + 2, "dim"),
-                    Span(len(_THIS_FILE.as_posix()) + 2, 55, Style()),
+                    Span(
+                        len(_THIS_FILE.as_posix()) + 2,
+                        len(_THIS_FILE.as_posix()) + 2 + 6,
+                        Style(),
+                    ),
                 ],
             ),
             id="format full id",

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -18,6 +18,10 @@ class _DummyTask(MetaTask):
     markers = attr.ib(factory=list)
     path = attr.ib(default=None)
     base_name = ""
+    short_name = attr.ib(init=False)
+
+    def __attrs_post_init__(self):
+        self.short_name = self.name
 
     def execute(self):
         ...

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -109,7 +109,7 @@ def test_node_and_neighbors(dag):
 )
 def test_extract_priorities_from_tasks(tasks, expectation, expected):
     with expectation:
-        result = _extract_priorities_from_tasks(tasks, [])
+        result = _extract_priorities_from_tasks(tasks)
         assert result == expected
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,10 +16,10 @@ def test_existence_of_hashes_in_db(tmp_path, runner):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy(produces):
+    def task_write(produces):
         produces.touch()
     """
-    task_path = tmp_path.joinpath("task_dummy.py")
+    task_path = tmp_path.joinpath("task_module.py")
     task_path.write_text(textwrap.dedent(source))
     in_path = tmp_path.joinpath("in.txt")
     in_path.touch()
@@ -35,7 +35,7 @@ def test_existence_of_hashes_in_db(tmp_path, runner):
             "sqlite", tmp_path.joinpath(".pytask.sqlite3").as_posix(), True, False
         )
 
-        task_id = task_path.as_posix() + "::task_dummy"
+        task_id = task_path.as_posix() + "::task_write"
         out_path = tmp_path.joinpath("out.txt")
 
         for id_, path in [

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -48,12 +48,12 @@ def _flush(child):
 @pytest.mark.skipif(sys.platform == "win32", reason="pexpect cannot spawn on Windows.")
 def test_post_mortem_on_error(tmp_path):
     source = """
-    def task_dummy():
+    def task_example():
         a = 'I am in the debugger. '
         b = 'For real!'
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask --pdb {tmp_path.as_posix()}")
     child.expect("Pdb")
@@ -72,11 +72,11 @@ def test_post_mortem_on_error_w_kwargs(tmp_path):
     from pathlib import Path
 
     @pytask.mark.depends_on(Path(__file__).parent / "in.txt")
-    def task_dummy(depends_on):
+    def task_example(depends_on):
         a = depends_on.read_text()
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("Stuck in the middle with you.")
 
     child = pexpect.spawn(f"pytask --pdb {tmp_path.as_posix()}")
@@ -92,10 +92,10 @@ def test_post_mortem_on_error_w_kwargs(tmp_path):
 @pytest.mark.skipif(sys.platform == "win32", reason="pexpect cannot spawn on Windows.")
 def test_trace(tmp_path):
     source = """
-    def task_dummy():
+    def task_example():
         i = 32345434
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask --trace {tmp_path.as_posix()}")
     child.expect("Pdb")
@@ -114,10 +114,10 @@ def test_trace_w_kwargs(tmp_path):
     from pathlib import Path
 
     @pytask.mark.depends_on(Path(__file__).parent / "in.txt")
-    def task_dummy(depends_on):
+    def task_example(depends_on):
         print(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("I want you back.")
 
     child = pexpect.spawn(f"pytask --trace {tmp_path.as_posix()}")
@@ -134,11 +134,11 @@ def test_trace_w_kwargs(tmp_path):
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="breakpoint is Python 3.7+ only.")
 def test_breakpoint(tmp_path):
     source = """
-    def task_dummy():
+    def task_example():
         i = 32345434
         breakpoint()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("Pdb")
@@ -154,11 +154,11 @@ def test_breakpoint(tmp_path):
 def test_pdb_set_trace(tmp_path):
     source = """
     import pdb
-    def task_dummy():
+    def task_example():
         i = 32345434
         pdb.set_trace()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("Pdb")
@@ -181,7 +181,7 @@ def test_pdb_interaction_capturing_simple(tmp_path):
         i == 1
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect(r"task_1\(\)")
@@ -209,7 +209,7 @@ def test_pdb_set_trace_kwargs(tmp_path):
         x = 3
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("== my_header ==")
@@ -232,7 +232,7 @@ def test_pdb_set_trace_interception(tmp_path):
     def task_1():
         pdb.set_trace()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("task_1")
@@ -260,7 +260,7 @@ def test_set_trace_capturing_afterwards(tmp_path):
         print("hello")
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("task_1")
@@ -287,7 +287,7 @@ def test_pdb_interaction_capturing_twice(tmp_path):
         x = 4
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect(["PDB", "set_trace", r"\(IO-capturing", "turned", r"off\)"])
@@ -355,10 +355,10 @@ def test_pdb_with_injected_do_debug(tmp_path):
         print("hello18")
         assert count_continue == 2, "unexpected_failure: %d != 2" % count_continue
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(
-        f"pytask --pdbcls=task_dummy:CustomPdb {tmp_path.as_posix()}",
+        f"pytask --pdbcls=task_example:CustomPdb {tmp_path.as_posix()}",
         env={"PATH": os.environ["PATH"], "PYTHONPATH": f"{tmp_path.as_posix()}"},
     )
 
@@ -399,7 +399,7 @@ def test_pdb_without_capture(tmp_path):
     def task_1():
         pdb.set_trace()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask -s {tmp_path.as_posix()}")
     child.expect(r"PDB set_trace")
@@ -419,7 +419,7 @@ def test_pdb_used_outside_task(tmp_path):
     pdb.set_trace()
     x = 5
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytask {tmp_path.as_posix()}")
     child.expect("x = 5")
@@ -431,7 +431,7 @@ def test_pdb_used_outside_task(tmp_path):
 @pytest.mark.end_to_end
 def test_printing_of_local_variables(tmp_path, runner):
     source = """
-    def task_dummy():
+    def task_example():
         a = 1
         helper()
 
@@ -439,7 +439,7 @@ def test_printing_of_local_variables(tmp_path, runner):
         b = 2
         raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "--show-locals"])
     assert result.exit_code == 1
@@ -462,7 +462,7 @@ def test_set_trace_is_returned_after_pytask_finishes(tmp_path):
         pytask.main({{"paths": "{tmp_path.as_posix()}"}})
         breakpoint()
     """
-    tmp_path.joinpath("test_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("test_example.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(f"pytest {tmp_path.as_posix()}")
     child.expect("breakpoint()")

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -358,7 +358,7 @@ def test_pdb_with_injected_do_debug(tmp_path):
     tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     child = pexpect.spawn(
-        f"pytask --pdbcls=task_example:CustomPdb {tmp_path.as_posix()}",
+        f"pytask --pdbcls=task_module:CustomPdb {tmp_path.as_posix()}",
         env={"PATH": os.environ["PATH"], "PYTHONPATH": f"{tmp_path.as_posix()}"},
     )
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -11,7 +11,7 @@ from pytask import main
 
 @pytest.mark.end_to_end
 def test_python_m_pytask(tmp_path):
-    tmp_path.joinpath("task_dummy.py").write_text("def task_dummy(): pass")
+    tmp_path.joinpath("task_module.py").write_text("def task_example(): pass")
     subprocess.run(["python", "-m", "pytask", tmp_path.as_posix()], check=True)
 
 
@@ -21,10 +21,10 @@ def test_task_did_not_produce_node(tmp_path):
     import pytask
 
     @pytask.mark.produces("out.txt")
-    def task_dummy():
+    def task_example():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -62,7 +62,7 @@ def test_node_not_found_in_task_setup(tmp_path):
     def task_3(depends_on):
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -87,7 +87,7 @@ def test_execution_w_varying_dependencies_products(tmp_path, dependencies, produ
 
     @pytask.mark.depends_on({dependencies})
     @pytask.mark.produces({products})
-    def task_dummy(depends_on, produces):
+    def task_example(depends_on, produces):
         if isinstance(produces, dict):
             produces = produces.values()
         elif isinstance(produces, Path):
@@ -95,7 +95,7 @@ def test_execution_w_varying_dependencies_products(tmp_path, dependencies, produ
         for product in produces:
             product.touch()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     for dependency in dependencies:
         tmp_path.joinpath(dependency).touch()
 
@@ -111,11 +111,11 @@ def test_depends_on_and_produces_can_be_used_in_task(tmp_path):
 
     @pytask.mark.depends_on("in.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy(depends_on, produces):
+    def task_example(depends_on, produces):
         assert isinstance(depends_on, Path) and isinstance(produces, Path)
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("Here I am. Once again.")
 
     session = main({"paths": tmp_path})
@@ -135,7 +135,7 @@ def test_assert_multiple_dependencies_are_merged_to_dict(tmp_path, runner):
     @pytask.mark.depends_on(["in_1.txt", "in_2.txt"])
     @pytask.mark.depends_on("in_0.txt")
     @pytask.mark.produces("out.txt")
-    def task_dummy(depends_on, produces):
+    def task_example(depends_on, produces):
         expected = {
             i: Path(__file__).parent.joinpath(f"in_{i}.txt").resolve()
             for i in range(7)
@@ -143,7 +143,7 @@ def test_assert_multiple_dependencies_are_merged_to_dict(tmp_path, runner):
         assert depends_on == expected
         produces.touch()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     for name in [f"in_{i}.txt" for i in range(7)]:
         tmp_path.joinpath(name).touch()
 
@@ -163,7 +163,7 @@ def test_assert_multiple_products_are_merged_to_dict(tmp_path, runner):
     @pytask.mark.produces({3: "out_3.txt", 4: "out_4.txt"})
     @pytask.mark.produces(["out_1.txt", "out_2.txt"])
     @pytask.mark.produces("out_0.txt")
-    def task_dummy(depends_on, produces):
+    def task_example(depends_on, produces):
         expected = {
             i: Path(__file__).parent.joinpath(f"out_{i}.txt").resolve()
             for i in range(7)
@@ -172,7 +172,7 @@ def test_assert_multiple_products_are_merged_to_dict(tmp_path, runner):
         for product in produces.values():
             product.touch()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").touch()
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
@@ -197,14 +197,14 @@ def test_preserve_input_for_dependencies_and_products(tmp_path, input_type):
 
     @pytask.mark.depends_on({input_})
     @pytask.mark.produces({output})
-    def task_dummy(depends_on, produces):
+    def task_example(depends_on, produces):
         for nodes in [depends_on, produces]:
             assert isinstance(nodes, dict)
             assert len(nodes) == 1
             assert 0 in nodes
         produces[0].touch()
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
     assert session.exit_code == 0
@@ -218,7 +218,7 @@ def test_execution_stops_after_n_failures(tmp_path, n_failures):
     def task_2(): raise Exception
     def task_3(): raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path, "max_failures": n_failures})
 
@@ -234,7 +234,7 @@ def test_execution_stop_after_first_failure(tmp_path, stop_after_first_failure):
     def task_2(): raise Exception
     def task_3(): raise Exception
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main(
         {"paths": tmp_path, "stop_after_first_failure": stop_after_first_failure}
@@ -257,7 +257,7 @@ def test_scheduling_w_priorities(tmp_path):
     @pytask.mark.try_last
     def task_y(): pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -276,7 +276,7 @@ def test_scheduling_w_mixed_priorities(runner, tmp_path):
     @pytask.mark.try_first
     def task_mixed(): pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -11,7 +11,7 @@ from pytask import main
 def test_ignore_default_paths(tmp_path, ignored_folder):
     folder = ignored_folder.split("/*")[0]
     tmp_path.joinpath(folder).mkdir()
-    tmp_path.joinpath(folder, "task_dummy.py").write_text("def task_d(): pass")
+    tmp_path.joinpath(folder, "task_module.py").write_text("def task_d(): pass")
 
     session = main({"paths": tmp_path})
     assert session.exit_code == 0
@@ -20,10 +20,10 @@ def test_ignore_default_paths(tmp_path, ignored_folder):
 
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("config_path", ["pytask.ini", "tox.ini", "setup.cfg"])
-@pytest.mark.parametrize("ignore", ["", "*task_dummy.py"])
+@pytest.mark.parametrize("ignore", ["", "*task_module.py"])
 @pytest.mark.parametrize("new_line", [True, False])
 def test_ignore_paths(tmp_path, config_path, ignore, new_line):
-    tmp_path.joinpath("task_dummy.py").write_text("def task_dummy(): pass")
+    tmp_path.joinpath("task_module.py").write_text("def task_example(): pass")
     entry = f"ignore =\n\t{ignore}" if new_line else f"ignore = {ignore}"
     config = f"[pytask]\n{entry}" if ignore else "[pytask]"
     tmp_path.joinpath(config_path).write_text(config)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -214,3 +214,25 @@ def test_full_execution_table_is_displayed_at_the_end_of_execution(tmp_path, run
     assert result.exit_code == 0
     for i in range(4):
         assert f"{i}.txt" in result.output
+
+
+@pytest.mark.end_to_end
+def test_execute_w_partialed_functions(tmp_path, runner):
+    """Test with partialed function which make it harder to extract info.
+
+    Info like source line number and the path to the module.
+
+    """
+    source = """
+    import functools
+
+    def func(): ...
+
+    task_func = functools.partial(func)
+
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+    result = runner.invoke(cli, [tmp_path.joinpath("task_module.py").as_posix()])
+
+    assert result.exit_code == 0
+    assert "task_func" in result.output

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -64,7 +64,7 @@ def test_live_execution_sequentially(capsys, tmp_path):
     task.short_name = "task_module.py::task_example"
 
     live_manager = LiveManager()
-    live = LiveExecution(live_manager, 20, 1)
+    live = LiveExecution(live_manager, 20, 1, "no_link")
 
     live_manager.start()
     live.update_running_tasks(task)
@@ -116,7 +116,7 @@ def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, o
     task.short_name = "task_module.py::task_example"
 
     live_manager = LiveManager()
-    live = LiveExecution(live_manager, 20, verbose)
+    live = LiveExecution(live_manager, 20, verbose, "no_link")
 
     live_manager.start()
     live.update_running_tasks(task)
@@ -158,7 +158,7 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
     running_task.short_name = "task_module.py::task_running"
 
     live_manager = LiveManager()
-    live = LiveExecution(live_manager, n_entries_in_table, 1)
+    live = LiveExecution(live_manager, n_entries_in_table, 1, "no_link")
 
     live_manager.start()
     live.update_running_tasks(running_task)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -42,8 +42,8 @@ def test_parse_n_entries_in_table(value, expectation, expected):
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("verbose", [False, True])
 def test_verbose_mode_execution(tmp_path, runner, verbose):
-    source = "def task_dummy(): pass"
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    source = "def task_example(): pass"
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     args = [tmp_path.as_posix()]
     if not verbose:
@@ -52,15 +52,16 @@ def test_verbose_mode_execution(tmp_path, runner, verbose):
 
     assert ("Task" in result.output) is verbose
     assert ("Outcome" in result.output) is verbose
-    assert ("task_dummy.py::task_dummy" in result.output) is verbose
+    assert ("task_module.py::task_example" in result.output) is verbose
 
 
 @pytest.mark.unit
 def test_live_execution_sequentially(capsys, tmp_path):
-    path = tmp_path.joinpath("task_dummy.py")
+    path = tmp_path.joinpath("task_module.py")
     task = PythonFunctionTask(
-        "task_dummy", path.as_posix() + "::task_dummy", path, lambda x: x
+        "task_example", path.as_posix() + "::task_example", path, lambda x: x
     )
+    task.short_name = "task_module.py::task_example"
 
     live_manager = LiveManager()
     live = LiveExecution(live_manager, [tmp_path], 20, 1)
@@ -73,7 +74,7 @@ def test_live_execution_sequentially(capsys, tmp_path):
     captured = capsys.readouterr()
     assert "Task" not in captured.out
     assert "Outcome" not in captured.out
-    assert "task_dummy.py::task_dummy" not in captured.out
+    assert "task_module.py::task_example" not in captured.out
     assert "running" not in captured.out
 
     live_manager.resume()
@@ -84,7 +85,7 @@ def test_live_execution_sequentially(capsys, tmp_path):
     captured = capsys.readouterr()
     assert "Task" in captured.out
     assert "Outcome" in captured.out
-    assert "task_dummy.py::task_dummy" in captured.out
+    assert "task_module.py::task_example" in captured.out
     assert "running" in captured.out
 
     live_manager.start()
@@ -99,7 +100,7 @@ def test_live_execution_sequentially(capsys, tmp_path):
     captured = capsys.readouterr()
     assert "Task" in captured.out
     assert "Outcome" in captured.out
-    assert "task_dummy.py::task_dummy" in captured.out
+    assert "task_module.py::task_example" in captured.out
     assert "running" not in captured.out
     assert TaskOutcome.SUCCESS.symbol in captured.out
 
@@ -108,10 +109,11 @@ def test_live_execution_sequentially(capsys, tmp_path):
 @pytest.mark.parametrize("verbose", [1, 2])
 @pytest.mark.parametrize("outcome", TaskOutcome)
 def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, outcome):
-    path = tmp_path.joinpath("task_dummy.py")
+    path = tmp_path.joinpath("task_module.py")
     task = PythonFunctionTask(
-        "task_dummy", path.as_posix() + "::task_dummy", path, lambda x: x
+        "task_example", path.as_posix() + "::task_example", path, lambda x: x
     )
+    task.short_name = "task_module.py::task_example"
 
     live_manager = LiveManager()
     live = LiveExecution(live_manager, [tmp_path], 20, verbose)
@@ -137,10 +139,10 @@ def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, o
         TaskOutcome.SKIP_PREVIOUS_FAILED,
         TaskOutcome.PERSISTENCE,
     ):
-        assert "task_dummy.py::task_dummy" not in captured.out
+        assert "task_module.py::task_example" not in captured.out
         assert f"│ {outcome.symbol}" not in captured.out
     else:
-        assert "task_dummy.py::task_dummy" in captured.out
+        assert "task_module.py::task_example" in captured.out
         assert f"│ {outcome.symbol}" in captured.out
 
     assert "running" not in captured.out
@@ -149,10 +151,11 @@ def test_live_execution_displays_skips_and_persists(capsys, tmp_path, verbose, o
 @pytest.mark.unit
 @pytest.mark.parametrize("n_entries_in_table", [1, 2])
 def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_table):
-    path = tmp_path.joinpath("task_dummy.py")
+    path = tmp_path.joinpath("task_module.py")
     running_task = PythonFunctionTask(
         "task_running", path.as_posix() + "::task_running", path, lambda x: x
     )
+    running_task.short_name = "task_module.py::task_running"
 
     live_manager = LiveManager()
     live = LiveExecution(live_manager, [tmp_path], n_entries_in_table, 1)
@@ -170,6 +173,7 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
     completed_task = PythonFunctionTask(
         "task_completed", path.as_posix() + "::task_completed", path, lambda x: x
     )
+    completed_task.short_name = "task_module.py::task_completed"
     live.update_running_tasks(completed_task)
     report = ExecutionReport(
         task=completed_task, outcome=TaskOutcome.SUCCESS, exc_info=None
@@ -181,19 +185,16 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
 
     # Test that report is or is not included.
     captured = capsys.readouterr()
-    print(captured)
     assert "Task" in captured.out
     assert "Outcome" in captured.out
     assert "::task_running" in captured.out
     assert " running " in captured.out
 
     if n_entries_in_table == 1:
-        assert "task_dummy.py::task_completed" not in captured.out.encode(
-            "ascii", "ignore"
-        )
+        assert "task_module.py::task_completed" not in captured.out
         assert "│ ." not in captured.out
     else:
-        assert "task_dummy.py::task_completed" in captured.out
+        assert "task_module.py::task_completed" in captured.out
         assert "│ ." in captured.out
 
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -181,13 +181,16 @@ def test_live_execution_displays_subset_of_table(capsys, tmp_path, n_entries_in_
 
     # Test that report is or is not included.
     captured = capsys.readouterr()
+    print(captured)
     assert "Task" in captured.out
     assert "Outcome" in captured.out
     assert "::task_running" in captured.out
     assert " running " in captured.out
 
     if n_entries_in_table == 1:
-        assert "task_dummy.py::task_completed" not in captured.out
+        assert "task_dummy.py::task_completed" not in captured.out.encode(
+            "ascii", "ignore"
+        )
         assert "│ ." not in captured.out
     else:
         assert "task_dummy.py::task_completed" in captured.out

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -103,7 +103,8 @@ def test_logging_of_outcomes(tmp_path, runner, func, expected_1, expected_2):
 @pytest.mark.parametrize(
     "amount, unit, short_label, expectation, expected",
     [
-        (173, "hours", False, does_not_raise(), [(7, "days"), (5, "hours")]),
+        (2.234, "seconds", True, does_not_raise(), [(2.23, "s")]),
+        (173, "hours", True, does_not_raise(), [(7, "d"), (5, "h")]),
         (1, "hour", False, does_not_raise(), [(1, "hour")]),
         (
             17281,
@@ -112,7 +113,6 @@ def test_logging_of_outcomes(tmp_path, runner, func, expected_1, expected_2):
             does_not_raise(),
             [(4, "hours"), (48, "minutes"), (1, "second")],
         ),
-        (173, "hours", True, does_not_raise(), [(7, "d"), (5, "h")]),
         (1, "hour", True, does_not_raise(), [(1, "h")]),
         (
             1,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -90,7 +90,7 @@ def test_logging_of_outcomes(tmp_path, runner, func, expected_1, expected_2):
 
     {func}
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert expected_1 in result.output

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -101,7 +101,7 @@ def test_ini_markers_whitespace(tmp_path, config_name):
             """
         )
     )
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             import pytask
@@ -131,7 +131,7 @@ def test_ini_markers_whitespace(tmp_path, config_name):
     ],
 )
 def test_mark_option(tmp_path, expr: str, expected_passed: str) -> None:
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             import pytask
@@ -171,7 +171,7 @@ def test_mark_option(tmp_path, expr: str, expected_passed: str) -> None:
     ],
 )
 def test_keyword_option_custom(tmp_path, expr: str, expected_passed: str) -> None:
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             def task_interface():
@@ -208,7 +208,7 @@ def test_keyword_option_custom(tmp_path, expr: str, expected_passed: str) -> Non
     ],
 )
 def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -> None:
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             import pytask
@@ -265,7 +265,7 @@ def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -
 def test_keyword_option_wrong_arguments(
     tmp_path, capsys, option: str, expr: str, expected_error: str
 ) -> None:
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent("def task_func(arg): pass")
     )
     session = main({"paths": tmp_path, option: expr})
@@ -299,7 +299,7 @@ def test_selecting_task_with_keyword_should_run_predecessor(runner, tmp_path):
     def task_second(depends_on):
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "-k", "second"])
 
@@ -321,7 +321,7 @@ def test_selecting_task_with_marker_should_run_predecessor(runner, tmp_path):
     def task_second(depends_on):
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 
@@ -341,7 +341,7 @@ def test_selecting_task_with_keyword_ignores_other_task(runner, tmp_path):
     def task_second():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "-k", "second"])
 
@@ -363,7 +363,7 @@ def test_selecting_task_with_marker_ignores_other_task(runner, tmp_path):
     def task_second():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -26,11 +26,11 @@ from _pytask.shared import reduce_node_name
 )
 def test_extract_args_from_mark(decorator, values, expected):
     @decorator(values)
-    def task_dummy():
+    def task_example():
         pass
 
     parser = depends_on if decorator.name == "depends_on" else produces
-    result = list(_extract_nodes_from_function_markers(task_dummy, parser))
+    result = list(_extract_nodes_from_function_markers(task_example, parser))
     assert result == expected
 
 
@@ -46,11 +46,11 @@ def test_extract_args_from_mark(decorator, values, expected):
 )
 def test_extract_kwargs_from_mark(decorator, values, expected):
     @decorator(**values)
-    def task_dummy():
+    def task_example():
         pass
 
     parser = depends_on if decorator.name == "depends_on" else produces
-    result = list(_extract_nodes_from_function_markers(task_dummy, parser))
+    result = list(_extract_nodes_from_function_markers(task_example, parser))
     assert result == expected
 
 
@@ -63,12 +63,12 @@ def test_raise_error_for_invalid_args_to_depends_on_and_produces(
     decorator, args, kwargs
 ):
     @decorator(*args, **kwargs)
-    def task_dummy():
+    def task_example():
         pass
 
     parser = depends_on if decorator.name == "depends_on" else produces
     with pytest.raises(TypeError):
-        list(_extract_nodes_from_function_markers(task_dummy, parser))
+        list(_extract_nodes_from_function_markers(task_example, parser))
 
 
 @pytest.mark.unit

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -169,7 +169,7 @@ def test_parametrizing_tasks(tmp_path):
     def task_write_numbers_to_file(produces, i):
         produces.write_text(str(i))
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -193,7 +193,7 @@ def test_parametrizing_dependencies_and_targets(tmp_path):
     def task_save_numbers_again(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -213,7 +213,7 @@ def test_parametrize_iterator(tmp_path):
     def task_func(a):
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     session = main({"paths": tmp_path})
     assert session.exit_code == 0
     assert len(session.execution_reports) == 3
@@ -228,7 +228,7 @@ def test_raise_error_if_function_does_not_use_parametrized_arguments(tmp_path):
     def task_func():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     session = main({"paths": tmp_path})
 
     assert session.exit_code == 1
@@ -245,7 +245,7 @@ def test_raise_error_if_function_does_not_use_parametrized_arguments(tmp_path):
     ],
 )
 def test_parametrize_w_ids(tmp_path, arg_values, ids):
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             f"""
             import pytask
@@ -266,7 +266,7 @@ def test_parametrize_w_ids(tmp_path, arg_values, ids):
 @pytest.mark.end_to_end
 @pytest.mark.xfail(strict=True, reason="Cartesian task product is disabled.")
 def test_two_parametrize_w_ids(tmp_path):
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             import pytask
@@ -291,7 +291,7 @@ def test_two_parametrize_w_ids(tmp_path):
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("ids", [["a"], list("abc"), ((1,), (2,)), ({0}, {1})])
 def test_raise_error_for_irregular_ids(tmp_path, ids):
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             f"""
             import pytask
@@ -332,7 +332,7 @@ def test_arg_value_to_id_component(arg_name, arg_value, i, id_func, expected):
 
 @pytest.mark.end_to_end
 def test_raise_error_if_parametrization_produces_non_unique_tasks(tmp_path):
-    tmp_path.joinpath("task_dummy.py").write_text(
+    tmp_path.joinpath("task_module.py").write_text(
         textwrap.dedent(
             """
             import pytask
@@ -398,7 +398,7 @@ def test_wrong_number_of_names_and_wrong_number_of_arguments(
     def task_func():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -40,7 +40,7 @@ def test_multiple_runs_with_persist(tmp_path):
     def task_dummy(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("I'm not the reason you care.")
 
     session = main({"paths": tmp_path})
@@ -65,7 +65,7 @@ def test_multiple_runs_with_persist(tmp_path):
         create_database(
             "sqlite", tmp_path.joinpath(".pytask.sqlite3").as_posix(), True, False
         )
-        task_id = tmp_path.joinpath("task_dummy.py").as_posix() + "::task_dummy"
+        task_id = tmp_path.joinpath("task_module.py").as_posix() + "::task_dummy"
         node_id = tmp_path.joinpath("out.txt").as_posix()
 
         state = State[task_id, node_id].state
@@ -90,7 +90,7 @@ def test_migrating_a_whole_task_with_persist(tmp_path):
     def task_dummy(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     for name in ["in.txt", "out.txt"]:
         tmp_path.joinpath(name).write_text(
             "They say oh my god I see the way you shine."

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -73,7 +73,7 @@ def test_profile_if_there_is_information_on_collected_tasks(tmp_path, runner):
 
     assert result.exit_code == 0
     assert "Collected 1 task." in result.output
-    assert "Last Duration (in s)" in result.output
+    assert "Duration (in s)" in result.output
     assert "0." in result.output
 
 
@@ -93,6 +93,6 @@ def test_export_of_profile(tmp_path, runner, export):
 
     assert result.exit_code == 0
     assert "Collected 1 task." in result.output
-    assert "Last Duration (in s)" in result.output
+    assert "Duration (in s)" in result.output
     assert "0." in result.output
     assert tmp_path.joinpath(f"profile.{export}").exists()

--- a/tests/test_resolve_dependencies.py
+++ b/tests/test_resolve_dependencies.py
@@ -146,7 +146,7 @@ def test_cycle_in_dag(tmp_path, runner):
     def task_2(produces):
         produces.write_text("2")
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 

--- a/tests/test_skipping.py
+++ b/tests/test_skipping.py
@@ -22,7 +22,7 @@ def test_skip_unchanged(tmp_path):
     def task_dummy():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
     assert session.execution_reports[0].outcome == TaskOutcome.SUCCESS
@@ -41,7 +41,7 @@ def test_skip_unchanged_w_dependencies_and_products(tmp_path):
     def task_dummy(depends_on, produces):
         produces.write_text(depends_on.read_text())
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
     tmp_path.joinpath("in.txt").write_text("Original content of in.txt.")
 
     session = main({"paths": tmp_path})
@@ -69,7 +69,7 @@ def test_skipif_ancestor_failed(tmp_path):
     def task_second():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -93,7 +93,7 @@ def test_if_skip_decorator_is_applied_to_following_tasks(tmp_path):
     def task_second():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -116,7 +116,7 @@ def test_skip_if_dependency_is_missing(tmp_path, mark_string):
     def task_first():
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
 
@@ -141,7 +141,7 @@ def test_skip_if_dependency_is_missing_only_for_one_task(runner, tmp_path, mark_
     def task_second():
         assert 0
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 
@@ -165,7 +165,7 @@ def test_if_skipif_decorator_is_applied_skipping(tmp_path):
     def task_second():
         assert False
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
     node = session.collection_reports[0].node
@@ -196,7 +196,7 @@ def test_if_skipif_decorator_is_applied_execute(tmp_path):
     def task_second():
         pass
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
     node = session.collection_reports[0].node
@@ -227,7 +227,7 @@ def test_if_skipif_decorator_is_applied_any_condition_matches(tmp_path):
     def task_second():
         assert False
     """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     session = main({"paths": tmp_path})
     node = session.collection_reports[0].node


### PR DESCRIPTION
#### Changes

- Add ``task.short_name`` which is the shortest version of the id which is still unique.
- Add `format_task_id` and use it in many places.
- Sort entries in execution table after the execution
- Make getting source lines robust to partialed functions.
- Round remaining seconds to two decimals.
- Never use dummy again.