### PR TITLE
Enhance live display by deactivating auto-refresh among other things.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,12 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 `Anaconda.org <https://anaconda.org/conda-forge/pytask>`_.
 
 
+0.1.5 - 2022-xx-xx
+------------------
+
+- :gh:`186` enhance live displays by deactivating auto-refresh among other things.
+
+
 0.1.4 - 2022-01-04
 ------------------
 
@@ -29,7 +35,6 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`182` introduces that only the starting year is displayed in the license following
   https://hynek.me/til/copyright-years.
 - :gh:`183` enables tracing down the source of a function through decorators.
-- :gh:`186` enhance live displays by deactivating auto-refresh among other things.
 
 
 0.1.3 - 2021-11-30

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -29,6 +29,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`182` introduces that only the starting year is displayed in the license following
   https://hynek.me/til/copyright-years.
 - :gh:`183` enables tracing down the source of a function through decorators.
+- :gh:`186` enhance live displays by deactivating auto-refresh among other things.
 
 
 0.1.3 - 2021-11-30


### PR DESCRIPTION
- Call refresh explicitly to update the graphic.
- At the end of the execution, remove the live display and print the table again for less artifacts.