### PR TITLE
Remove internal traceback frames from exceptions raised within pytask.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -21,6 +21,8 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :gh:`200` implements the :func:`@pytask.mark.task <_pytask.task.task>` decorator to
   mark functions as tasks regardless whether they are prefixed with ``task_`` or not.
 - :gh:`201` adds tests for ``_pytask.mark_utils``.
+- :gh:`204` removes internal traceback frames from exceptions raised somewhere in
+  pytask.
 
 
 0.1.5 - 2022-01-10

--- a/src/_pytask/build.py
+++ b/src/_pytask/build.py
@@ -14,6 +14,8 @@ from _pytask.exceptions import ResolvingDependenciesError
 from _pytask.outcomes import ExitCode
 from _pytask.pluginmanager import get_plugin_manager
 from _pytask.session import Session
+from _pytask.traceback import remove_internal_traceback_frames_from_exc_info
+from rich.traceback import Traceback
 
 
 if TYPE_CHECKING:
@@ -78,7 +80,10 @@ def main(config_from_cli: Dict[str, Any]) -> Session:
             session.exit_code = ExitCode.FAILED
 
         except Exception:
-            console.print_exception()
+            exc_info = sys.exc_info()
+            exc_info = remove_internal_traceback_frames_from_exc_info(exc_info)
+            traceback = Traceback.from_exception(*exc_info)
+            console.print(traceback)
             session.exit_code = ExitCode.FAILED
 
         session.hook.pytask_unconfigure(session=session)


### PR DESCRIPTION
### Changes

Allows to raise exceptions, for example, in plugins and remove all traceback frames via ``__tracebackhide__``.