### PR TITLE
Remove `depends_on` and `produces` from task function when parsed.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,13 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 `Anaconda.org <https://anaconda.org/conda-forge/pytask>`_.
 
 
+0.1.9 - 2022-xx-xx
+------------------
+
+- :gh:`217` enhances the tutorial on how to set up a project.
+- :gh:`218` removes ``depends_on`` and ``produces`` from the task function when parsed.
+
+
 0.1.8 - 2022-02-07
 ------------------
 
@@ -14,7 +21,6 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
   exception as an input. Closes :gh:`145`.
 - :gh:`213` improves coverage and reporting.
 - :gh:`215` makes the help pages of the CLI prettier.
-- :gh:`217` enhances the tutorial on how to set up a project.
 
 
 0.1.7 - 2022-01-28

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import attr
 from _pytask.exceptions import NodeNotCollectedError
 from _pytask.exceptions import NodeNotFoundError
-from _pytask.mark_utils import get_marks_from_obj
+from _pytask.mark_utils import remove_markers_from_func
 from _pytask.session import Session
 
 
@@ -147,7 +147,7 @@ class PythonFunctionTask(MetaTask):
         markers = [
             marker
             for marker in getattr(function, "pytaskmark", [])
-            if marker.name not in ["depends_on", "produces"]
+            if marker.name not in ("depends_on", "produces")
         ]
 
         return cls(
@@ -174,7 +174,7 @@ class PythonFunctionTask(MetaTask):
         """Process dependencies and products to pass them as kwargs to the function."""
         func_arg_names = set(inspect.signature(self.function).parameters)
         kwargs = {}
-        for arg_name in ["depends_on", "produces"]:
+        for arg_name in ("depends_on", "produces"):
             if arg_name in func_arg_names:
                 attribute = getattr(self, arg_name)
                 kwargs[arg_name] = (
@@ -280,7 +280,8 @@ def _extract_nodes_from_function_markers(
 
     """
     marker_name = parser.__name__
-    for marker in get_marks_from_obj(function, marker_name):
+    _, markers = remove_markers_from_func(function, marker_name)
+    for marker in markers:
         parsed = parser(*marker.args, **marker.kwargs)
         yield parsed
 

--- a/src/_pytask/parametrize.py
+++ b/src/_pytask/parametrize.py
@@ -132,6 +132,10 @@ def pytask_parametrize_task(
             partialed_func = functools.partial(func, **kwargs)
             wrapped_func = functools.update_wrapper(partialed_func, func)
 
+            # Remove markers from wrapped function since they are not used. See
+            # https://github.com/pytask-dev/pytask/issues/216.
+            wrapped_func.func.pytaskmark = []  # type: ignore[attr-defined]
+
             name_ = f"{name}[{'-'.join(itertools.chain.from_iterable(names))}]"
             names_and_functions.append((name_, wrapped_func))
 
@@ -395,7 +399,7 @@ def _arg_value_to_id_component(
 def pytask_parametrize_kwarg_to_marker(obj: Any, kwargs: dict[str, str]) -> None:
     """Add some parametrized keyword arguments as decorator."""
     if callable(obj):
-        for marker_name in ["depends_on", "produces"]:
+        for marker_name in ("depends_on", "produces"):
             if marker_name in kwargs:
                 mark.__getattr__(marker_name)(kwargs.pop(marker_name))(obj)
 


### PR DESCRIPTION
Closes #216.