### PR TITLE
Fix a circular import error created by #197.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -17,6 +17,7 @@ all releases are available on `PyPI <https://pypi.org/project/pytask>`_ and
 - :pull:`219` removes some leftovers from pytest in :class:`~_pytask.mark.Mark`.
 - :pull:`221` adds more test cases for parametrizations.
 - :pull:`222` adds an automated Github Actions job for creating a list pytask plugins.
+- :pull:`225` fixes a circular import noticeable in plugins created by :pull:`197`.
 
 
 0.1.8 - 2022-02-07

--- a/src/pytask/__init__.py
+++ b/src/pytask/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from _pytask import __version__
 from _pytask.build import main
-from _pytask.cli import cli
 from _pytask.compat import check_for_optional_program
 from _pytask.compat import import_optional_dependency
 from _pytask.config import hookimpl
@@ -31,6 +30,9 @@ from _pytask.outcomes import SkippedAncestorFailed
 from _pytask.outcomes import SkippedUnchanged
 from _pytask.outcomes import TaskOutcome
 from _pytask.session import Session
+
+# This import must come last, otherwise a circular import occurs.
+from _pytask.cli import cli  # noreorder
 
 
 __all__ = [


### PR DESCRIPTION
#### Changes

Move the import of `cli.py` to the lowest position in `pytask/__init__.py`.

When `cli` is imported, plugins will be imported before other modules like `pytask.mark` have been imported. But, plugins will also try to import `from pytask import Mark` which will cause the circular import error.

I am not sure whether this is a permanent fix.