### PR TITLE
Allow any order of decorators with `@pytask.mark.task`.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -24,7 +24,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
   {mod}`_pytask.mark_utils`. (Closes {issue}`220`.)
 - {pull}`236` refactors {mod}`_pytask.collect` and places shared functions in
   {mod}`_pytask.collect_utils`.
-
+- {pull}`238` allows any order of decorators with a `@pytask.mark.task` decorator.
 
 ## 0.1.9 - 2022-02-23
 

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -121,6 +121,10 @@ def pytask_collect_file(
 
         collected_reports = []
         for name, obj in inspect.getmembers(mod):
+            # Ensures that tasks with this decorator are only collected once.
+            if has_mark(obj, "task"):
+                continue
+
             if has_mark(obj, "parametrize"):
                 names_and_objects = session.hook.pytask_parametrize_task(
                     session=session, name=name, obj=obj

--- a/src/_pytask/task_utils.py
+++ b/src/_pytask/task_utils.py
@@ -71,10 +71,7 @@ def task(
 
         COLLECTED_TASKS[path].append(unwrapped)
 
-        # Returning None is necessary since the remaining function in the module will be
-        # collected again from the namespace, although we already collect the function
-        # from ``COLLECTED_TASKS``.
-        return None
+        return unwrapped
 
     # In case the decorator is used without parentheses, wrap the function which is
     # passed as the first argument with the default arguments.

--- a/src/_pytask/task_utils.py
+++ b/src/_pytask/task_utils.py
@@ -160,6 +160,8 @@ def _generate_ids_for_tasks(
     for i, (name, task) in enumerate(tasks):
         if task.pytask_meta.id_ is not None:  # type: ignore[attr-defined]
             id_ = f"{name}[{str(task.pytask_meta.id_)}]"  # type: ignore[attr-defined]
+        elif not parameters:
+            id_ = f"{name}[{i}]"
         else:
             stringified_args = [
                 arg_value_to_id_component(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -240,3 +240,121 @@ def test_parametrization_in_for_loop_from_decorator_w_irregular_dicts(tmp_path, 
     assert "1  Succeeded"
     assert "1  Failed"
     assert "TypeError: example() missing 1 required" in result.output
+
+
+@pytest.mark.end_to_end
+def test_parametrization_in_for_loop_with_one_iteration(tmp_path, runner):
+    source = """
+    import pytask
+
+    for i in range(1):
+
+        @pytask.mark.task
+        @pytask.mark.produces(f"out_{i}.txt")
+        def task_example(produces):
+            produces.write_text("Your advertisement could be here.")
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_example " in result.output
+    assert "Collect 1 task"
+
+
+@pytest.mark.end_to_end
+def test_parametrization_in_for_loop_and_normal(tmp_path, runner):
+    source = """
+    import pytask
+
+    for i in range(1):
+
+        @pytask.mark.task
+        @pytask.mark.produces(f"out_{i}.txt")
+        def task_example(produces):
+            produces.write_text("Your advertisement could be here.")
+
+    @pytask.mark.task
+    @pytask.mark.produces(f"out_1.txt")
+    def task_example(produces):
+        produces.write_text("Your advertisement could be here.")
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_example[produces0]" in result.output
+    assert "task_example[produces1]" in result.output
+    assert "Collect 2 tasks"
+
+
+@pytest.mark.end_to_end
+def test_parametrized_names_without_parametrization(tmp_path, runner):
+    source = """
+    import pytask
+
+    for i in range(2):
+
+        @pytask.mark.task
+        @pytask.mark.produces(f"out_{i}.txt")
+        def task_example(produces):
+            produces.write_text("Your advertisement could be here.")
+
+    @pytask.mark.task
+    @pytask.mark.produces(f"out_2.txt")
+    def task_example(produces):
+        produces.write_text("Your advertisement could be here.")
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_example[produces0]" in result.output
+    assert "task_example[produces1]" in result.output
+    assert "task_example[produces2]" in result.output
+    assert "Collect 3 tasks"
+
+
+@pytest.mark.end_to_end
+def test_order_of_decorator_does_not_matter(tmp_path, runner):
+    source = """
+    import pytask
+
+    @pytask.mark.skip
+    @pytask.mark.task
+    @pytask.mark.produces(f"out.txt")
+    def task_example(produces):
+        produces.write_text("Your advertisement could be here.")
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_example" in result.output
+    assert "1  Skipped" in result.output
+
+
+@pytest.mark.end_to_end
+def test_task_function_with_partialed_args(tmp_path, runner):
+    source = """
+    import pytask
+    import functools
+
+    def func(produces, content):
+        produces.write_text(content)
+
+    task_func = pytask.mark.produces("out.txt")(
+        pytask.mark.skip(functools.partial(func, content="hello"))
+    )
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_func" in result.output
+    assert "1  Skipped" in result.output

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -334,11 +334,11 @@ def test_order_of_decorator_does_not_matter(tmp_path, runner):
     result = runner.invoke(cli, [tmp_path.as_posix()])
 
     assert result.exit_code == ExitCode.OK
-    assert "task_example" in result.output
     assert "1  Skipped" in result.output
 
 
 @pytest.mark.end_to_end
+@pytest.mark.xfail(reason="Partialed functions are not supported.")
 def test_task_function_with_partialed_args(tmp_path, runner):
     source = """
     import pytask

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -369,7 +369,7 @@ def test_parametrized_tasks_without_arguments_in_signature(tmp_path, runner):
     import pytask
     from pathlib import Path
 
-    for i in range(2):
+    for i in range(1):
 
         @pytask.mark.task
         @pytask.mark.produces(f"out_{{i}}.txt")
@@ -378,7 +378,15 @@ def test_parametrized_tasks_without_arguments_in_signature(tmp_path, runner):
                 "I use globals. How funny."
             )
 
+
     @pytask.mark.task
+    @pytask.mark.produces("out_1.txt")
+    def task_example():
+        Path("{tmp_path.as_posix()}").joinpath("out_1.txt").write_text(
+            "I use globals. How funny."
+        )
+
+    @pytask.mark.task(id="hello")
     @pytask.mark.produces("out_2.txt")
     def task_example():
         Path("{tmp_path.as_posix()}").joinpath("out_2.txt").write_text(
@@ -392,5 +400,5 @@ def test_parametrized_tasks_without_arguments_in_signature(tmp_path, runner):
     assert result.exit_code == ExitCode.OK
     assert "task_example[0]" in result.output
     assert "task_example[1]" in result.output
-    assert "task_example[2]" in result.output
+    assert "task_example[hello]" in result.output
     assert "Collect 3 tasks"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -303,7 +303,7 @@ def test_parametrized_names_without_parametrization(tmp_path, runner):
             produces.write_text("Your advertisement could be here.")
 
     @pytask.mark.task
-    @pytask.mark.produces(f"out_2.txt")
+    @pytask.mark.produces("out_2.txt")
     def task_example(produces):
         produces.write_text("Your advertisement could be here.")
     """
@@ -358,3 +358,39 @@ def test_task_function_with_partialed_args(tmp_path, runner):
     assert result.exit_code == ExitCode.OK
     assert "task_func" in result.output
     assert "1  Skipped" in result.output
+
+
+@pytest.mark.end_to_end
+def test_parametrized_tasks_without_arguments_in_signature(tmp_path, runner):
+    """This happens when plugins replace the function with its own implementation. Then,
+    there is usually no point in adding arguments to the function signature. Or when
+    people build weird workarounds like the one below."""
+    source = f"""
+    import pytask
+    from pathlib import Path
+
+    for i in range(2):
+
+        @pytask.mark.task
+        @pytask.mark.produces(f"out_{{i}}.txt")
+        def task_example():
+            Path("{tmp_path.as_posix()}").joinpath(f"out_{{i}}.txt").write_text(
+                "I use globals. How funny."
+            )
+
+    @pytask.mark.task
+    @pytask.mark.produces("out_2.txt")
+    def task_example():
+        Path("{tmp_path.as_posix()}").joinpath("out_2.txt").write_text(
+            "I use globals. How funny."
+        )
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.OK
+    assert "task_example[0]" in result.output
+    assert "task_example[1]" in result.output
+    assert "task_example[2]" in result.output
+    assert "Collect 3 tasks"


### PR DESCRIPTION
#### Changes

- Make the task decorator return the function so that following decorators are still applied to the function.
- Fix the collection to not collect a task twice.
- Improve the generation of the signature of parametrized tasks when no args are in the signature.