### PR TITLE
Add support for `pyproject.toml`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,11 @@ repos:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
     -   id: setup-cfg-fmt
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
@@ -68,7 +68,7 @@ repos:
             Pygments,
         ]
 -   repo: https://github.com/PyCQA/doc8
-    rev: 0.10.1
+    rev: 0.11.1
     hooks:
     -   id: doc8
 -   repo: https://github.com/asottile/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
         ]
         additional_dependencies: [
             attrs>=19.2.0,
-            types-click,
+            click,
             types-setuptools
         ]
         pass_filenames: false

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -29,8 +29,8 @@ dependencies:
   - pybaum
   - pexpect
   - rich
-  - tomli
-  - tomli-w
+  - tomli >=1.0.0
+  - tomli-w >=1.0.0
 
   - pip:
     - ../

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - sphinx-autoapi
   - sphinx-click
   - sphinx-copybutton
-  - sphinx-inline-tabs
   - sphinx-panels
 
   # Package dependencies necessary for sphinx-click

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - sphinx-autoapi
   - sphinx-click
   - sphinx-copybutton
+  - sphinx-inline-tabs
   - sphinx-panels
 
   # Package dependencies necessary for sphinx-click
@@ -30,6 +31,7 @@ dependencies:
   - pexpect
   - rich
   - tomli
+  - tomli-w
 
   - pip:
     - ../

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -20,16 +20,16 @@ dependencies:
   - sphinx-panels
 
   # Package dependencies necessary for sphinx-click
-  - attrs >=17.4.0
+  - attrs >=19.2.0
   - click
   - click-default-group
-  - networkx
+  - networkx >=2.4
   - pluggy
   - pony >=0.7.15
   - pybaum
   - pexpect
   - rich
-  - typing-extensions
+  - tomli
 
   - pip:
     - ../

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -34,7 +34,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 - {pull}`245` adds choices on the command line to the help pages as metavars and show
   defaults.
 - {pull}`246` formalizes choices for {class}`click.Choice` to {class}`enum.Enum`.
-- {pull}`248` adds a counter at the bottom of the execution table to show how many tasks
+- {pull}`252` adds a counter at the bottom of the execution table to show how many tasks
   have been processed.
 
 ## 0.1.9 - 2022-02-23

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -36,6 +36,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 - {pull}`246` formalizes choices for {class}`click.Choice` to {class}`enum.Enum`.
 - {pull}`252` adds a counter at the bottom of the execution table to show how many tasks
   have been processed.
+- {pull}`253` adds support for ``pyproject.toml``.
 
 ## 0.1.9 - 2022-02-23
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "sphinx_click",
+    "sphinx_inline_tabs",
     "sphinx_panels",
     "autoapi.extension",
     "myst_parser",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "sphinx_click",
-    "sphinx_inline_tabs",
     "sphinx_panels",
     "autoapi.extension",
     "myst_parser",

--- a/docs/source/how_to_guides/bp_parametrizations.md
+++ b/docs/source/how_to_guides/bp_parametrizations.md
@@ -26,7 +26,7 @@ First, let us take a look at the folder and file structure of such a project.
 
 ```
 my_project
-├───pytask.ini or tox.ini or setup.cfg
+├───pyproject.toml
 │
 ├───src
 │   └───my_project

--- a/docs/source/reference_guides/configuration.md
+++ b/docs/source/reference_guides/configuration.md
@@ -1,24 +1,17 @@
 # The configuration
 
-This document lists all options to configure pytask via the configuration files.
+This document lists all options to configure pytask with a `pyproject.toml` file.
 
 ## The basics
 
 To learn about the basics visit the {doc}`tutorial <../tutorials/configuration>`.
 
-## Truthy and falsy values
+Examples for the TOML specification be found [here](https://toml.io/en/) or in [PEP
+518](https://peps.python.org/pep-0518/).
 
-For some of the configuration values you need truthy or falsy values. pytask recognizes
-the following values.
-
-- truthy: `True`, `true`, `1`.
-- falsy: `False`, `false`, `0`.
-
-Additionally, the following values are interpreted as None which is neither truthy or
-falsy.
-
-- `None`
-- `none`
+The configuration values are set under the `[tool.pytask.ini_options]` section to mimic
+the old ini configurations and to allow pytask leveraging the full potential of the TOML
+format in the future.
 
 ## The options
 
@@ -34,7 +27,7 @@ falsy.
     If you have very strong reasons for relying on this inaccuracy, although, it is
     strongly discouraged, you can deactivate the warning in the configuration file with
 
-    .. code-block:: ini
+    .. code-block:: toml
 
         check_casing_of_paths = false
 
@@ -52,31 +45,31 @@ falsy.
     the modules in which tasks are defined. By default, following the link will open the
     module with your default application. It is done with
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        editor_url_scheme = file
+        editor_url_scheme = "file"
 
     If you use ``vscode`` or ``pycharm`` instead, the file will be opened in the
     specified editor and the cursor will also jump to the corresponding line.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        editor_url_scheme = vscode | pycharm
+        editor_url_scheme = "vscode" | "pycharm"
 
     For complete flexibility, you can also enter a custom url which can use the
     variables ``path`` and ``line_number`` to open the file.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        editor_url_scheme = editor://{path}:{line_number}
+        editor_url_scheme = "editor://{path}:{line_number}"
 
     Maybe you want to contribute this URL scheme to make it available to more people.
 
     To disable links, use
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        editor_url_scheme = no_link
+        editor_url_scheme = "no_link"
 
 ```
 
@@ -95,15 +88,13 @@ falsy.
 
     Or, use the configuration file:
 
-    .. code-block:: ini
+    .. code-block:: toml
 
         # For single entries only.
-        ignore = some_file.py
+        ignore = "some_file.py"
 
         # Or single and multiple entries.
-        ignore =
-            some_directory/*
-            some_file.py
+        ignore = ["some_directory/*", "some_file.py"]
 
 ```
 
@@ -123,10 +114,10 @@ falsy.
     silence the warning and document the marker, provide the following information in
     your pytask configuration file.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        markers =
-            wip: Work-in-progress. These are tasks which I am currently working on.
+        [tool.pytask.ini_options.markers]
+        wip = "Work-in-progress. These are tasks which I am currently working on."
 
 ```
 
@@ -143,9 +134,9 @@ falsy.
 
     and in the configuration use
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        n_entries_in_table = all  # default 15
+        n_entries_in_table = "all"  # default 15
 
 ```
 
@@ -156,15 +147,13 @@ falsy.
     command line, you can add the paths to the configuration file. Paths passed via the
     command line will overwrite the configuration value.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
         # For single entries only.
-        paths = src
+        paths = "src"
 
         # Or single and multiple entries.
-        paths =
-            folder_1
-            folder_2/task_2.py
+        paths = ["folder_1", "folder_2/task_2.py"]
 
 ```
 
@@ -180,9 +169,9 @@ falsy.
 
     or use a truthy configuration value.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        pdb = True
+        pdb = true
 
 ```
 
@@ -196,9 +185,9 @@ falsy.
 
         pytask build --show-errors-immediately
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        show_errors_immediately = True
+        show_errors_immediately = true
 
 ```
 
@@ -212,9 +201,9 @@ falsy.
 
         pytask build --show-locals
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        show_locals = True
+        show_locals = true
 
 ```
 
@@ -229,9 +218,9 @@ falsy.
 
     or set the option to a truthy value.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        strict_markers = True
+        strict_markers = true
 
 ```
 
@@ -240,13 +229,11 @@ falsy.
 
     Change the pattern which identify task files.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        task_files = task_*.py  # default
+        task_files = "task_*.py"  # default
 
-        task_files =
-            task_*.py
-            tasks_*.py
+        task_files = ["task_*.py", "tasks_*.py"]
 
 ```
 
@@ -261,7 +248,7 @@ falsy.
 
     or set this option to a truthy value.
 
-    .. code-block:: ini
+    .. code-block:: toml
 
-        trace = True
+        trace = true
 ```

--- a/docs/source/tutorials/configuration.md
+++ b/docs/source/tutorials/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 pytask can be configured via the command-line interface or permanently with a
-configuration file.
+`pyproject.toml` file.
 
 The file also indicates the root of your project where pytask stores information on
 whether tasks need to be executed or not in a `.pytask.sqlite3` database.

--- a/docs/source/tutorials/configuration.md
+++ b/docs/source/tutorials/configuration.md
@@ -3,32 +3,43 @@
 pytask can be configured via the command-line interface or permanently with a
 configuration file.
 
+The file also indicates the root of your project where pytask stores information on
+whether tasks need to be executed or not in a `.pytask.sqlite3` database.
+
+:::{important}
+pytask.ini, tox.ini, and setup.cfg will be deprecated as configuration files for pytask
+starting with v0.3 or v1.0. Switch to a `pyproject.toml` file! If you execute pytask
+with an old configuration file, pytask provides you with a copy-paste snippet of your
+configuration in the `toml` format to facilitate the transition.
+:::
+
 ## The configuration file
 
-pytask accepts configurations in three files which are `pytask.ini`, `tox.ini` and
-`setup.cfg`. Place a `[pytask]` section in those files and add your configuration below.
+You only need to add the header to the configuration file if you want to indicate the
+root of your project.
 
-```ini
-# Content of tox.ini
-
-[pytask]
-ignore =
-    some_path
+```toml
+[tool.pytask.ini_options]
 ```
 
-You can also leave the section empty. It will still have the benefit that pytask has a
-stable root and will store the information about tasks, dependencies, and products in
-the same directory as the configuration file in a database called `.pytask.sqlite3`.
+We can also overwrite pytask's behavior of collecting tasks from the current working
+directory and, instead, search for paths in a directory called `src` next to the
+configuration file.
+
+```toml
+[tool.pytask.ini_options]
+paths = src
+```
 
 ## The location
 
-There are two ways to find the configuration file when invoking pytask.
+There are two ways to point pytask to the configuration file.
 
 First, it is possible to pass the location of the configuration file via
 {option}`pytask build -c` like
 
 ```console
-$ pytask -c config/pytask.ini
+$ pytask -c config/pyproject.toml
 ```
 
 The second option is to let pytask try to find the configuration itself.

--- a/docs/source/tutorials/configuration.md
+++ b/docs/source/tutorials/configuration.md
@@ -31,13 +31,14 @@ First, it is possible to pass the location of the configuration file via
 $ pytask -c config/pytask.ini
 ```
 
-The second option is to let pytask try to find the configuration itself. pytask will
-first look in the current working directory or the common ancestors of multiple paths to
-tasks. It will search for `pytask.ini`, `tox.ini` and `setup.cfg` in this order.
-Whenever a `[pytask]` section is found, the search stops.
+The second option is to let pytask try to find the configuration itself.
 
-If no file is found in the current directory, pytask will climb up the directory tree
-and search in parent directories.
+1. Find the common base directory of all paths passed to pytask (default to the current
+   working directory).
+2. Starting from this directory, look at all parent directories, and return the file if
+   it is found.
+3. If a directory contains a `.git` directory/file, a `.hg` directory or a valid
+   configuration file with the right section stop searching.
 
 ## The options
 

--- a/docs/source/tutorials/set_up_a_project.md
+++ b/docs/source/tutorials/set_up_a_project.md
@@ -37,7 +37,7 @@ folder of the project and contains a `[tool.pytask.ini_options]` section.
 
 ```toml
 [tool.pytask.ini_options]
-paths = ./src/my_project
+paths = "src/my_project"
 ```
 
 You can also leave the section empty. The header alone will signal pytask that this is
@@ -46,6 +46,11 @@ the root of the project. pytask will store information it needs across execution
 
 `paths` allows you to set the location of tasks when you do not pass them explicitly via
 the cli.
+
+:::{seealso}
+You can find more information in the {doc}`tutorial <configuration>` or a full list in
+the {doc}`reference guide <../reference_guides/configuration>`.
+:::
 
 ### The source directory
 

--- a/docs/source/tutorials/set_up_a_project.md
+++ b/docs/source/tutorials/set_up_a_project.md
@@ -13,7 +13,7 @@ The following directory tree is an example of how a project can be set up.
 
 ```
 my_project
-├───pytask.ini or tox.ini or setup.cfg
+├───pyproject.toml
 │
 ├───src
 │   └───my_project
@@ -32,25 +32,20 @@ my_project
 
 ### The configuration
 
-The configuration resides in either a `pytask.ini`, `tox.ini`, or `setup.cfg` file. The
-file is placed in the root folder of the project and contains a `[pytask]` section which
-can be left empty. Here, we set `paths` such that it points to the project.
+The configuration resides in a `pyproject.toml` file. The file is placed in the root
+folder of the project and contains a `[tool.pytask.ini_options]` section.
 
-```ini
-# Content of pytask.ini, tox.ini or setup.cfg.
-
-[pytask]
+```toml
+[tool.pytask.ini_options]
 paths = ./src/my_project
 ```
 
-The file in combination with an empty section will signal the root of the project to
-pytask. This has two benefits.
+You can also leave the section empty. The header alone will signal pytask that this is
+the root of the project. pytask will store information it needs across executions in a
+`.pytask.sqlite3` database next to the configuration file.
 
-1. pytask needs to save some data across executions. It will store this information in a
-   `.pytask.sqlite3` database in the root folder.
-1. If you start pytask without a path - simply `pytask` - from a different location
-   inside the project folder than the root, the database will be found and pytask runs
-   as if it is run in the project root.
+`paths` allows you to set the location of tasks when you do not pass them explicitly via
+the cli.
 
 ### The source directory
 

--- a/docs/source/tutorials/write_a_task.md
+++ b/docs/source/tutorials/write_a_task.md
@@ -13,7 +13,7 @@ function in the module {func}`task_create_random_data`.
 
 ```
 my_project
-├───pytask.ini or tox.ini or setup.cfg
+├───pyproject.toml
 │
 ├───src
 │   └───my_project

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - pybaum
   - rich
   - tomli
+  - tomli-w
 
   # Misc
   - black
@@ -46,6 +47,7 @@ dependencies:
   - sphinx-autoapi
   - sphinx-click
   - sphinx-copybutton
+  - sphinx-inline-tabs
   - sphinx-panels
 
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,6 @@ dependencies:
   - sphinx-autoapi
   - sphinx-click
   - sphinx-copybutton
-  - sphinx-inline-tabs
   - sphinx-panels
 
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -24,8 +24,8 @@ dependencies:
   - pony >=0.7.15
   - pybaum
   - rich
-  - tomli
-  - tomli-w
+  - tomli >=1.0.0
+  - tomli-w >=1.0.0
 
   # Misc
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pony >=0.7.15
   - pybaum
   - rich
-  - typing-extensions
+  - tomli
 
   # Misc
   - black

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     pybaum
     rich
     tomli>=1.0.0
+    tomli-w>=1.0.0
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     pony>=0.7.15
     pybaum
     rich
+    tomli>=1.0.0
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     pony>=0.7.15
     pybaum
     rich
-    typing-extensions
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/src/_pytask/build.py
+++ b/src/_pytask/build.py
@@ -61,7 +61,10 @@ def main(config_from_cli: dict[str, Any]) -> Session:
         session = Session.from_config(config)
 
     except (ConfigurationError, Exception):
-        console.print_exception()
+        exc_info = sys.exc_info()
+        exc_info = remove_internal_traceback_frames_from_exc_info(exc_info)
+        traceback = Traceback.from_exception(*exc_info)
+        console.print(traceback)
         session = Session({}, None)
         session.exit_code = ExitCode.CONFIGURATION_FAILED
 

--- a/src/_pytask/capture.py
+++ b/src/_pytask/capture.py
@@ -38,7 +38,6 @@ from typing import Generator
 from typing import Generic
 from typing import Iterator
 from typing import TextIO
-from typing import TYPE_CHECKING
 
 import click
 from _pytask.config import hookimpl
@@ -48,12 +47,7 @@ from _pytask.nodes import Task
 from _pytask.shared import get_first_non_none_value
 
 
-if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import final as final
-    else:
-        from typing_extensions import final as final
-elif sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8):
     from typing import final as final
 else:
 

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -254,8 +254,10 @@ def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
                 try:
                     read_config = get_config_reader(path)
                     read_config(path)
-                except (configparser.Error, tomli.TOMLDecodeError) as e:
-                    raise OSError(f"Could not read {path}.") from e
+                except configparser.Error as e:
+                    raise configparser.Error(f"Could not read {path}.") from e
+                except tomli.TOMLDecodeError as e:
+                    raise tomli.TOMLDecodeError(f"Could not read {path}.") from e
                 except KeyError:
                     pass
                 else:

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -100,7 +100,7 @@ def pytask_configure(
             if config_from_cli.get("paths") is not None
             else [Path.cwd()]
         )
-        config["root"], config["config"] = _find_project_root_and_ini(paths)
+        config["root"], config["config"] = _find_project_root_and_config(paths)
 
     if config["config"] is None:
         config_from_file = {}
@@ -236,7 +236,7 @@ def pytask_post_parse(config: dict[str, Any]) -> None:
     config["markers"] = {k: config["markers"][k] for k in sorted(config["markers"])}
 
 
-def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
+def _find_project_root_and_config(paths: list[Path]) -> tuple[Path, Path]:
     """Find the project root and configuration file from a list of paths.
 
     The process is as follows:

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -246,7 +246,7 @@ def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
     parent_directories = [common_ancestor] + list(common_ancestor.parents)
 
     for parent in parent_directories:
-        for config_name in ["pytask.ini", "tox.ini", "setup.cfg"]:
+        for config_name in ["pyproject.toml", "pytask.ini", "tox.ini", "setup.cfg"]:
 
             path = parent.joinpath(config_name)
 

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -10,12 +10,16 @@ from typing import Any
 
 import pluggy
 import tomli
+import tomli_w
 from _pytask.config_utils import get_config_reader
+from _pytask.console import console
 from _pytask.shared import convert_truthy_or_falsy_to_bool
 from _pytask.shared import get_first_non_none_value
 from _pytask.shared import parse_paths
 from _pytask.shared import parse_value_or_multiline_option
 from _pytask.shared import to_list
+from rich.syntax import Syntax
+from rich.text import Text
 
 
 hookimpl = pluggy.HookimplMarker("pytask")
@@ -70,6 +74,14 @@ def is_file_system_case_sensitive() -> bool:
 IS_FILE_SYSTEM_CASE_SENSITIVE = is_file_system_case_sensitive()
 
 
+_DEPRECATION_MESSAGE = """WARNING: pytask.ini, tox.ini, and setup.cfg will be \
+deprecated as configuration files for pytask starting with v0.3 or v1.0. To upgrade \
+and silence this warning, copy the content below in a pyproject.toml in the same \
+directory as your old configuration file. It is equivalent to your current \
+configuration.
+"""
+
+
 @hookimpl
 def pytask_configure(
     pm: pluggy.PluginManager, config_from_cli: dict[str, Any]
@@ -95,6 +107,13 @@ def pytask_configure(
     else:
         read_config = get_config_reader(config["config"])
         config_from_file = read_config(config["config"])
+
+        if read_config.__name__ == "_read_ini_config":
+            toml_string = tomli_w.dumps(
+                {"tool": {"pytask": {"ini_options": config_from_file}}}
+            )
+            console.print(Text(_DEPRECATION_MESSAGE, style="warning"))
+            console.print(Syntax(toml_string, "toml"))
 
     # If paths are set in the configuration, process them.
     if config_from_file.get("paths"):

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import configparser
-import itertools
 import os
 import tempfile
 import warnings
@@ -10,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 import pluggy
+import tomli
+from _pytask.config_utils import get_config_reader
 from _pytask.shared import convert_truthy_or_falsy_to_bool
 from _pytask.shared import get_first_non_none_value
 from _pytask.shared import parse_paths
@@ -79,7 +80,7 @@ def pytask_configure(
     # Either the path to the configuration is passed via the CLI or it needs to be
     # detected from the paths passed to pytask.
     if config_from_cli.get("config"):
-        config["config"] = Path.cwd().joinpath(config_from_cli["config"])
+        config["config"] = Path(config_from_cli["config"])
         config["root"] = config["config"].parent
     else:
         paths = (
@@ -89,9 +90,11 @@ def pytask_configure(
         )
         config["root"], config["config"] = _find_project_root_and_ini(paths)
 
-    config_from_file = (
-        _read_config(config["config"]) if config["config"] is not None else {}
-    )
+    if config["config"] is None:
+        config_from_file = {}
+    else:
+        read_config = get_config_reader(config["config"])
+        config_from_file = read_config(config["config"])
 
     # If paths are set in the configuration, process them.
     if config_from_file.get("paths"):
@@ -215,7 +218,18 @@ def pytask_post_parse(config: dict[str, Any]) -> None:
 
 
 def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
-    """Find the project root and configuration file from a list of paths."""
+    """Find the project root and configuration file from a list of paths.
+
+    The process is as follows:
+
+    1. Find the common base directory of all paths passed to pytask (default to the
+       current working directory).
+    2. Starting from this directory, look at all parent directories, and return the file
+       if it is found.
+    3. If a directory contains a ``.git`` directory/file, a ``.hg`` directory, or the
+       pyproject.toml file, stop searching.
+
+    """
     try:
         common_ancestor = Path(os.path.commonpath(paths))
     except ValueError:
@@ -224,37 +238,39 @@ def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
             "current working directory."
         )
         common_ancestor = Path.cwd()
+    if common_ancestor.is_file():
+        common_ancestor = common_ancestor.parent
 
     config_path = None
-    parent_directories = (
-        common_ancestor.parents
-        if common_ancestor.is_file()
-        else [common_ancestor] + list(common_ancestor.parents)
-    )
-    for parent, config_name in itertools.product(
-        parent_directories, ["pytask.ini", "tox.ini", "setup.cfg"]
-    ):
-        path = parent.joinpath(config_name)
+    root = None
+    parent_directories = [common_ancestor] + list(common_ancestor.parents)
 
-        if path.exists():
-            try:
-                _read_config(path)
-            except KeyError:
-                pass
-            else:
-                config_path = path
-                break
+    for parent in parent_directories:
+        for config_name in ["pytask.ini", "tox.ini", "setup.cfg"]:
 
-    if config_path is not None:
-        root = config_path.parent
-    else:
-        root = common_ancestor if common_ancestor.is_dir() else common_ancestor.parent
+            path = parent.joinpath(config_name)
+
+            if path.exists():
+                try:
+                    read_config = get_config_reader(path)
+                    read_config(path)
+                except (configparser.Error, tomli.TOMLDecodeError, KeyError):
+                    pass
+                else:
+                    config_path = path
+                    root = config_path.parent
+                    break
+
+        # If you hit a the top of a repository, stop searching further.
+        if parent.joinpath(".git").exists():
+            root = parent
+            break
+
+        if parent.joinpath(".hg").is_dir():
+            root = parent
+            break
+
+    if root is None:
+        root = common_ancestor
 
     return root, config_path
-
-
-def _read_config(path: Path) -> dict[str, Any]:
-    """Read the configuration from a file with a [pytask] section."""
-    config = configparser.ConfigParser()
-    config.read(path)
-    return dict(config["pytask"])

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -254,7 +254,9 @@ def _find_project_root_and_ini(paths: list[Path]) -> tuple[Path, Path]:
                 try:
                     read_config = get_config_reader(path)
                     read_config(path)
-                except (configparser.Error, tomli.TOMLDecodeError, KeyError):
+                except (configparser.Error, tomli.TOMLDecodeError) as e:
+                    raise OSError(f"Could not read {path}.") from e
+                except KeyError:
                     pass
                 else:
                     config_path = path

--- a/src/_pytask/config_utils.py
+++ b/src/_pytask/config_utils.py
@@ -1,8 +1,14 @@
 """This module contains helper functions for the configuration."""
 from __future__ import annotations
 
+import configparser
+import fnmatch
 from enum import Enum
+from pathlib import Path
+from typing import Any
 from typing import Callable
+
+import tomli
 
 
 def parse_click_choice(
@@ -28,3 +34,66 @@ class ShowCapture(Enum):
     STDOUT = "stdout"
     STDERR = "stderr"
     ALL = "all"
+
+
+def _read_ini_config(path: Path, sections: str = "pytask") -> dict[str, Any]:
+    """Read the configuration from a ``*.ini`` file.
+
+    Raises
+    ------
+    configparser.Error
+        Raised if ``*.ini`` could not be read.
+    KeyError
+        Raised if the specified sections do not exist.
+
+    """
+    sections_ = sections.split(".")
+
+    config = configparser.ConfigParser()
+    config.read(path, encoding="utf-8")
+
+    config_ = dict(config)
+    for section in sections_:
+        config_ = dict(config_[section])  # type: ignore
+
+    return config_
+
+
+def _read_toml_config(
+    path: Path, sections: str = "tool.pytask.ini_options"
+) -> dict[str, Any]:
+    """Read the configuration from a ``*.toml`` file.
+
+    Raises
+    ------
+    tomli.TOMLDecodeError
+        Raised if ``*.toml`` could not be read.
+    KeyError
+        Raised if the specified sections do not exist.
+
+    """
+    sections_ = sections.split(".")
+
+    config = tomli.loads(path.read_text(encoding="utf-8"))
+
+    for section in sections_:
+        config = config[section]
+
+    return config
+
+
+def get_config_reader(path: Path) -> Callable[[Path], dict[str, Any]]:
+    """Get a loader for a config file."""
+    loaders = {
+        "*.ini": _read_ini_config,
+        "*.cfg": _read_ini_config,
+        "*.toml": _read_toml_config,
+    }
+
+    for pattern, loader in loaders.items():
+        matches = fnmatch.fnmatch(path.as_posix(), pattern)
+
+        if matches:
+            return loader
+    else:
+        return _read_ini_config

--- a/src/_pytask/database.py
+++ b/src/_pytask/database.py
@@ -80,7 +80,7 @@ def pytask_extend_command_line_interface(cli: click.Group) -> None:
         ),
         click.Option(
             ["--database-filename"],
-            type=click.Path(),
+            type=str,
             help=(
                 "Path to database relative to root. "
                 "[dim]\\[default: .pytask.sqlite3][/]"

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -6,7 +6,6 @@ import sys
 import warnings
 from typing import Any
 from typing import NamedTuple
-from typing import TYPE_CHECKING
 
 import _pytask
 import click
@@ -26,15 +25,6 @@ try:
     from pluggy._manager import DistFacade
 except ImportError:
     from pluggy.manager import DistFacade
-
-
-if TYPE_CHECKING and sys.version_info >= (3, 8):
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
-
-    _ShowTraceback = Literal["no", "yes"]
 
 
 class _TimeUnit(NamedTuple):

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -132,7 +132,7 @@ def pytask_parse_config(
 def _read_marker_mapping(x: dict[str, str] | str) -> dict[str, str]:
     """Read marker descriptions from configuration file."""
     if isinstance(x, dict):
-        mapping = x
+        mapping = {k.strip(): v.strip() for k, v in x.items()}
     elif isinstance(x, str):
         # Split by newlines and remove empty strings.
         lines = filter(lambda i: bool(i), x.split("\n"))
@@ -144,7 +144,7 @@ def _read_marker_mapping(x: dict[str, str] | str) -> dict[str, str]:
                 key = line
                 value = ""
 
-            mapping[key] = value
+            mapping[key.strip()] = value.strip()
     else:
         raise TypeError(f"Unknown type {type(x)!r}. Expected dict or str.")
 

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -133,6 +133,8 @@ def _read_marker_mapping(x: dict[str, str] | str) -> dict[str, str]:
     """Read marker descriptions from configuration file."""
     if isinstance(x, dict):
         mapping = {k.strip(): v.strip() for k, v in x.items()}
+    elif isinstance(x, list):
+        mapping = {k.strip(): "" for k in x}
     elif isinstance(x, str):
         # Split by newlines and remove empty strings.
         lines = filter(lambda i: bool(i), x.split("\n"))

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -112,7 +112,7 @@ def pytask_parse_config(
     config_from_file: dict[str, Any],
 ) -> None:
     """Parse marker related options."""
-    markers = _read_marker_mapping_from_ini(config_from_file.get("markers", ""))
+    markers = _read_marker_mapping(config_from_file.get("markers", {}))
     config["markers"] = {**markers, **config["markers"]}
     config["strict_markers"] = get_first_non_none_value(
         config,
@@ -129,23 +129,30 @@ def pytask_parse_config(
     MARK_GEN.config = config
 
 
-def _read_marker_mapping_from_ini(string: str) -> dict[str, str]:
+def _read_marker_mapping(x: dict[str, str] | str) -> dict[str, str]:
     """Read marker descriptions from configuration file."""
-    # Split by newlines and remove empty strings.
-    lines = filter(lambda x: bool(x), string.split("\n"))
-    mapping = {}
-    for line in lines:
-        try:
-            key, value = line.split(":")
-        except ValueError as e:
-            key = line
-            value = ""
-            if not key.isidentifier():
-                raise ValueError(
-                    f"{key} is not a valid Python name and cannot be used as a marker."
-                ) from e
+    if isinstance(x, dict):
+        mapping = x
+    elif isinstance(x, str):
+        # Split by newlines and remove empty strings.
+        lines = filter(lambda i: bool(i), x.split("\n"))
+        mapping = {}
+        for line in lines:
+            try:
+                key, value = line.split(":")
+            except ValueError:
+                key = line
+                value = ""
 
-        mapping[key] = value
+            mapping[key] = value
+    else:
+        raise TypeError(f"Unknown type {type(x)!r}. Expected dict or str.")
+
+    for key in mapping:
+        if not key.isidentifier():
+            raise ValueError(
+                f"{key} is not a valid Python name and cannot be used as a marker."
+            )
 
     return mapping
 

--- a/src/_pytask/mark/structures.py
+++ b/src/_pytask/mark/structures.py
@@ -181,23 +181,15 @@ class MarkGenerator:
 
     config: dict[str, Any] | None = None
     """Optional[Dict[str, Any]]: The configuration."""
-    markers: set[str] = set()
-    """Set[str]: The set of markers."""
 
     def __getattr__(self, name: str) -> MarkDecorator | Any:
         if name[0] == "_":
             raise AttributeError("Marker name must NOT start with underscore")
 
         if self.config is not None:
-            # We store a set of markers as a performance optimization - if a mark
-            # name is in the set we definitely know it, but a mark may be known and
-            # not in the set.  We therefore start by updating the set!
-            if name not in self.markers:
-                self.markers.update(self.config["markers"])
-
             # If the name is not in the set of known marks after updating,
             # then it really is time to issue a warning or an error.
-            if name not in self.markers:
+            if name not in self.config["markers"]:
                 if self.config["strict_markers"]:
                     raise ValueError(f"Unknown pytask.mark.{name}.")
                 # Raise a specific error for common misspellings of "parametrize".

--- a/src/_pytask/parameters.py
+++ b/src/_pytask/parameters.py
@@ -7,7 +7,9 @@ from _pytask.shared import falsy_to_none_callback
 
 
 _CONFIG_OPTION = click.Option(
-    ["-c", "--config"], type=click.Path(exists=True), help="Path to configuration file."
+    ["-c", "--config"],
+    type=click.Path(exists=True, resolve_path=True),
+    help="Path to configuration file.",
 )
 """click.Option: An option for the --config flag."""
 
@@ -25,16 +27,19 @@ _IGNORE_OPTION = click.Option(
 
 
 _PATH_ARGUMENT = click.Argument(
-    ["paths"], nargs=-1, type=click.Path(exists=True), callback=falsy_to_none_callback
+    ["paths"],
+    nargs=-1,
+    type=click.Path(exists=True, resolve_path=True),
+    callback=falsy_to_none_callback,
 )
 """click.Argument: An argument for paths."""
 
 
 _VERBOSE_OPTION = click.Option(
     ["-v", "--verbose"],
-    type=int,
+    type=click.IntRange(0, 2),
     default=None,
-    help="Make pytask verbose (>= 0) or quiet (< 0) [dim]\\[default: 0][/]",
+    help="Make pytask verbose (>= 0) or quiet (= 0) [dim]\\[default: 1][/]",
 )
 """click.Option: An option to control pytask's verbosity."""
 

--- a/src/_pytask/shared.py
+++ b/src/_pytask/shared.py
@@ -112,6 +112,8 @@ def parse_value_or_multiline_option(value: str | None) -> None | str | list[str]
     """Parse option which can hold a single value or values separated by new lines."""
     if value in ["none", "None", None, ""]:
         return None
+    elif isinstance(value, list):
+        return list(map(str, value))
     elif isinstance(value, str) and "\n" in value:
         return [v.strip() for v in value.split("\n") if v.strip()]
     elif isinstance(value, str):

--- a/src/_pytask/traceback.py
+++ b/src/_pytask/traceback.py
@@ -100,10 +100,12 @@ def _filter_internal_traceback_frames(
 
     """
     frame = exc_info[2]
-    for frame in _yield_traceback_frames(frame):
-        if frame is None or not _is_internal_or_hidden_traceback_frame(frame, exc_info):
+    for frame_ in _yield_traceback_frames(frame):
+        if frame_ is None or not _is_internal_or_hidden_traceback_frame(
+            frame_, exc_info
+        ):
             break
-    return frame
+    return frame_
 
 
 def _yield_traceback_frames(

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -129,6 +129,34 @@ def test_collect_files_w_custom_file_name_pattern(
     assert len(session.tasks) == expected_collected_tasks
 
 
+@pytest.mark.end_to_end
+@pytest.mark.parametrize(
+    "task_files, pattern, expected_collected_tasks",
+    [
+        (["example_task.py"], "'*_task.py'", 1),
+        (["tasks_example.py"], "'tasks_*'", 1),
+        (["example_tasks.py"], "'*_tasks.py'", 1),
+        (["task_module.py", "tasks_example.py"], "'None'", 1),
+        (["task_module.py", "tasks_example.py"], "'tasks_*.py'", 1),
+        (["task_module.py", "tasks_example.py"], "['task_*.py', 'tasks_*.py']", 2),
+    ],
+)
+def test_collect_files_w_custom_file_name_pattern_toml(
+    tmp_path, task_files, pattern, expected_collected_tasks
+):
+    tmp_path.joinpath("pyproject.toml").write_text(
+        f"[tool.pytask.ini_options]\ntask_files = {pattern}"
+    )
+
+    for file in task_files:
+        tmp_path.joinpath(file).write_text("def task_example(): pass")
+
+    session = main({"paths": tmp_path})
+
+    assert session.exit_code == ExitCode.OK
+    assert len(session.tasks) == expected_collected_tasks
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "session, path, node, expectation, expected",

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -169,7 +169,6 @@ def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
     source = """
     import pytask
 
-    @pytask.mark.wip
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
     def task_example_1():
@@ -222,7 +221,6 @@ def test_collect_task_with_ignore_from_cli(runner, tmp_path):
     source = """
     import pytask
 
-    @pytask.mark.wip
     @pytask.mark.depends_on("in_1.txt")
     @pytask.mark.produces("out_1.txt")
     def task_example_1():

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -164,6 +164,56 @@ def test_collect_task_with_marker(runner, tmp_path, config_name):
 
 
 @pytest.mark.end_to_end
+def test_collect_task_with_marker_toml(runner, tmp_path):
+    source = """
+    import pytask
+
+    @pytask.mark.wip
+    @pytask.mark.depends_on("in_1.txt")
+    @pytask.mark.produces("out_1.txt")
+    def task_example_1():
+        pass
+
+    @pytask.mark.depends_on("in_2.txt")
+    @pytask.mark.produces("out_2.txt")
+    def task_example_2():
+        pass
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
+
+    config = """
+    [tool.pytask.ini_options]
+    markers = {'wip' = 'A work-in-progress marker.'}
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(config))
+
+    result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "-m", "wip"])
+
+    captured = result.output.replace("\n", "").replace(" ", "")
+    assert "<Module" in captured
+    assert "task_module.py>" in captured
+    assert "<Function" in captured
+    assert "task_example_1>" in captured
+    assert "<Function" in captured
+    assert "task_example_2>" not in captured
+
+    result = runner.invoke(
+        cli, ["collect", tmp_path.as_posix(), "-m", "wip", "--nodes"]
+    )
+
+    captured = result.output.replace("\n", "").replace(" ", "")
+    assert "<Module" in captured
+    assert "task_module.py>" in captured
+    assert "<Function" in captured
+    assert "task_example_1>" in captured
+    assert "<Dependency" in captured
+    assert "in_1.txt>" in captured
+    assert "<Product" in captured
+    assert "out_1.txt>" in captured
+
+
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
 def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
     source = """
@@ -190,6 +240,58 @@ def test_collect_task_with_ignore_from_config(runner, tmp_path, config_name):
     ignore = task_example_2.py
     """
     tmp_path.joinpath(config_name).write_text(textwrap.dedent(config))
+
+    result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
+
+    captured = result.output.replace("\n", "").replace(" ", "")
+    assert "<Module" in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
+    assert "<Function" in captured
+    assert "task_example_1>" in captured
+    assert "<Function" in captured
+    assert "task_example_2>" not in captured
+
+    result = runner.invoke(cli, ["collect", tmp_path.as_posix(), "--nodes"])
+
+    captured = result.output.replace("\n", "").replace(" ", "")
+    assert "<Module" in captured
+    assert "task_example_1.py>" in captured
+    assert "task_example_2.py>" not in captured
+    assert "<Function" in captured
+    assert "task_example_1>" in captured
+    assert "<Dependency" in captured
+    assert "in_1.txt>" in captured
+    assert "<Product" in captured
+    assert "out_1.txt>" in captured
+
+
+@pytest.mark.end_to_end
+def test_collect_task_with_ignore_from_config_toml(runner, tmp_path):
+    source = """
+    import pytask
+
+    @pytask.mark.depends_on("in_1.txt")
+    @pytask.mark.produces("out_1.txt")
+    def task_example_1():
+        pass
+    """
+    tmp_path.joinpath("task_example_1.py").write_text(textwrap.dedent(source))
+
+    source = """
+    @pytask.mark.depends_on("in_2.txt")
+    @pytask.mark.produces("out_2.txt")
+    def task_example_2():
+        pass
+    """
+    tmp_path.joinpath("task_example_2.py").write_text(textwrap.dedent(source))
+    tmp_path.joinpath("in_1.txt").touch()
+
+    config = """
+    [tool.pytask.ini_options]
+    ignore = "task_example_2.py"
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(config))
 
     result = runner.invoke(cli, ["collect", tmp_path.as_posix()])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,6 +85,20 @@ def test_pass_config_to_cli(tmp_path, config_path):
 
 
 @pytest.mark.end_to_end
+def test_pass_config_to_cli_toml(tmp_path):
+    config = """
+    [tool.pytask.ini_options]
+    markers = {"elton" = "Can you feel the love tonight?"}
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(config))
+
+    session = main({"config": tmp_path.joinpath("pyproject.toml"), "paths": tmp_path})
+
+    assert session.exit_code == ExitCode.OK
+    assert "elton" in session.config["markers"]
+
+
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("config_path", ["pytask.ini", "tox.ini", "setup.cfg"])
 def test_prioritize_given_config_over_others(tmp_path, config_path):
     config = """
@@ -100,6 +114,24 @@ def test_prioritize_given_config_over_others(tmp_path, config_path):
             tmp_path.joinpath(config_name).write_text(textwrap.dedent(config))
 
     session = main({"config": tmp_path.joinpath(config_path), "paths": tmp_path})
+
+    assert session.exit_code == ExitCode.OK
+    assert "kylie" in session.config["markers"]
+
+
+@pytest.mark.end_to_end
+def test_prioritize_given_config_over_others_toml(tmp_path):
+    config = """
+    [tool.pytask.ini_options]
+    markers = {"kylie" = "I just can't get you out of my head."}
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(config))
+
+    for config_name in ["pytask.ini", "tox.ini", "setup.cfg"]:
+        config = "[pytask]\nmarkers=bad_config: Wrong config loaded"
+        tmp_path.joinpath(config_name).write_text(textwrap.dedent(config))
+
+    session = main({"config": tmp_path.joinpath("pyproject.toml"), "paths": tmp_path})
 
     assert session.exit_code == ExitCode.OK
     assert "kylie" in session.config["markers"]
@@ -126,6 +158,30 @@ def test_passing_paths_via_configuration_file(tmp_path, config_path, file_or_fol
         )
 
     session = main({"config": tmp_path.joinpath(config_path)})
+
+    assert session.exit_code == ExitCode.OK
+    assert len(session.tasks) == 1
+
+
+@pytest.mark.end_to_end
+@pytest.mark.parametrize(
+    "file_or_folder",
+    ["folder_a", "folder_a/task_a.py", "folder_b", "folder_b/task_b.py"],
+)
+def test_passing_paths_via_configuration_file_toml(tmp_path, file_or_folder):
+    config = f"""
+    [tool.pytask.ini_options]
+    paths = "{file_or_folder}"
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(config))
+
+    for letter in ["a", "b"]:
+        tmp_path.joinpath(f"folder_{letter}").mkdir()
+        tmp_path.joinpath(f"folder_{letter}", f"task_{letter}.py").write_text(
+            "def task_passes(): pass"
+        )
+
+    session = main({"config": tmp_path.joinpath("pyproject.toml")})
 
     assert session.exit_code == ExitCode.OK
     assert len(session.tasks) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 
 import pytest
-from _pytask.config import _find_project_root_and_ini
+from _pytask.config import _find_project_root_and_config
 from pytask import ExitCode
 from pytask import main
 
@@ -17,7 +17,7 @@ from pytask import main
         (None, ["task_module.py"], "", None),
     ],
 )
-def test_find_project_root_and_ini(
+def test_find_project_root_and_config(
     tmp_path, in_ini, paths, expected_root, expected_ini
 ):
     if in_ini is not None:
@@ -36,7 +36,7 @@ def test_find_project_root_and_ini(
             path.parent.mkdir(exist_ok=True, parents=True)
             path.touch()
 
-    root, ini = _find_project_root_and_ini(paths)
+    root, ini = _find_project_root_and_config(paths)
 
     assert root == tmp_path.joinpath(expected_root)
     if expected_ini is None:
@@ -47,9 +47,9 @@ def test_find_project_root_and_ini(
 
 @pytest.mark.unit
 @pytest.mark.parametrize("paths", [None, ["/mnt/home/", "C:/Users/"]])
-def test_find_project_root_and_ini_raise_warning(paths):
+def test_find_project_root_and_config_raise_warning(paths):
     with pytest.warns(UserWarning, match="A common path for all passed path"):
-        _find_project_root_and_ini(paths)
+        _find_project_root_and_config(paths)
 
 
 @pytest.mark.end_to_end
@@ -200,7 +200,7 @@ def test_root_stops_at_version_control_folder(tmp_path, vc_folder, path, expecte
     if vc_folder:
         tmp_path.joinpath(vc_folder).mkdir(parents=True)
 
-    root, ini = _find_project_root_and_ini([tmp_path.joinpath(path)])
+    root, ini = _find_project_root_and_config([tmp_path.joinpath(path)])
 
     assert ini is None
     assert root == tmp_path.joinpath(expected)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -49,10 +49,20 @@ def test_existence_of_hashes_in_db(tmp_path, runner):
 
 
 @pytest.mark.end_to_end
-def test_rename_database_w_config(tmp_path, runner):
+@pytest.mark.parametrize("config_path", ["pytask.ini", "tox.ini", "setup.cfg"])
+def test_rename_database_w_config(tmp_path, runner, config_path):
     """Modification dates of input and output files are stored in database."""
-    tmp_path.joinpath("pytask.ini").write_text(
-        "[pytask]\ndatabase_filename=.db.sqlite3"
+    tmp_path.joinpath(config_path).write_text("[pytask]\ndatabase_filename=.db.sqlite3")
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == ExitCode.OK
+    tmp_path.joinpath(".db.sqlite3").exists()
+
+
+@pytest.mark.end_to_end
+def test_rename_database_w_config_toml(tmp_path, runner):
+    """Modification dates of input and output files are stored in database."""
+    tmp_path.joinpath("pyproject.toml").write_text(
+        "[tool.pytask.ini_options]\ndatabase_filename=.db.sqlite3"
     )
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.OK

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -48,3 +48,22 @@ def test_existence_of_hashes_in_db(tmp_path, runner):
         ]:
             state = State[task_id, id_].state
             assert float(state) == path.stat().st_mtime
+
+
+@pytest.mark.end_to_end
+def test_rename_database_w_config(tmp_path, runner):
+    """Modification dates of input and output files are stored in database."""
+    tmp_path.joinpath("pytask.ini").write_text(
+        "[pytask]\ndatabase_filename=.db.sqlite3"
+    )
+    result = runner.invoke(cli)
+    assert result.exit_code == ExitCode.OK
+    tmp_path.joinpath(".db.sqlite3").exists()
+
+
+@pytest.mark.end_to_end
+def test_rename_database_w_cli(tmp_path, runner):
+    """Modification dates of input and output files are stored in database."""
+    result = runner.invoke(cli, ["--database-filename", ".db.sqlite3"])
+    assert result.exit_code == ExitCode.OK
+    tmp_path.joinpath(".db.sqlite3").exists()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -62,7 +62,7 @@ def test_rename_database_w_config(tmp_path, runner, config_path):
 def test_rename_database_w_config_toml(tmp_path, runner):
     """Modification dates of input and output files are stored in database."""
     tmp_path.joinpath("pyproject.toml").write_text(
-        "[tool.pytask.ini_options]\ndatabase_filename=.db.sqlite3"
+        "[tool.pytask.ini_options]\ndatabase_filename='.db.sqlite3'"
     )
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.OK

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import textwrap
 
 import pytest
@@ -27,8 +26,7 @@ def test_existence_of_hashes_in_db(tmp_path, runner):
     in_path = tmp_path.joinpath("in.txt")
     in_path.touch()
 
-    os.chdir(tmp_path)
-    result = runner.invoke(cli)
+    result = runner.invoke(cli, [tmp_path.as_posix()])
 
     assert result.exit_code == ExitCode.OK
 
@@ -56,7 +54,7 @@ def test_rename_database_w_config(tmp_path, runner):
     tmp_path.joinpath("pytask.ini").write_text(
         "[pytask]\ndatabase_filename=.db.sqlite3"
     )
-    result = runner.invoke(cli)
+    result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.OK
     tmp_path.joinpath(".db.sqlite3").exists()
 
@@ -64,6 +62,8 @@ def test_rename_database_w_config(tmp_path, runner):
 @pytest.mark.end_to_end
 def test_rename_database_w_cli(tmp_path, runner):
     """Modification dates of input and output files are stored in database."""
-    result = runner.invoke(cli, ["--database-filename", ".db.sqlite3"])
+    result = runner.invoke(
+        cli, ["--database-filename", ".db.sqlite3", tmp_path.as_posix()]
+    )
     assert result.exit_code == ExitCode.OK
     tmp_path.joinpath(".db.sqlite3").exists()

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -36,6 +36,22 @@ def test_ignore_paths(tmp_path, config_path, ignore, new_line):
     assert len(session.tasks) == 0 if ignore else len(session.tasks) == 1
 
 
+@pytest.mark.end_to_end
+@pytest.mark.parametrize("ignore", ["", "*task_module.py"])
+@pytest.mark.parametrize("new_line", [True, False])
+def test_ignore_paths_toml(tmp_path, ignore, new_line):
+    tmp_path.joinpath("task_module.py").write_text("def task_example(): pass")
+    entry = f"ignore = ['{ignore}']" if new_line else f"ignore = '{ignore}'"
+    config = (
+        f"[tool.pytask.ini_options]\n{entry}" if ignore else "[tool.pytask.ini_options]"
+    )
+    tmp_path.joinpath("pyproject.toml").write_text(config)
+
+    session = main({"paths": tmp_path})
+    assert session.exit_code == ExitCode.OK
+    assert len(session.tasks) == 0 if ignore else len(session.tasks) == 1
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "path, ignored_paths, expected",

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -103,12 +103,12 @@ def test_markers_command(tmp_path, runner, config_name):
 
 @pytest.mark.end_to_end
 def test_markers_command_toml(tmp_path, runner):
-    ini = """
+    toml = """
     [tool.pytask.ini_options]
     markers = ["a1", "a2", "nodescription"]
     """
     config_path = tmp_path.joinpath("pyproject.toml")
-    config_path.write_text(textwrap.dedent(ini))
+    config_path.write_text(textwrap.dedent(toml))
 
     result = runner.invoke(cli, ["markers", "-c", config_path.as_posix()])
     assert result.exit_code == ExitCode.OK

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -94,7 +94,7 @@ def test_markers_command(tmp_path, runner, config_name):
 @pytest.mark.end_to_end
 @pytest.mark.filterwarnings("ignore:Unknown pytask.mark.")
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
-def test_ini_markers_whitespace(tmp_path, config_name):
+def test_ini_markers_whitespace(runner, tmp_path, config_name):
     tmp_path.joinpath(config_name).write_text(
         textwrap.dedent(
             """
@@ -115,9 +115,9 @@ def test_ini_markers_whitespace(tmp_path, config_name):
         )
     )
 
-    session = main({"paths": tmp_path, "strict_markers": True})
-    assert session.exit_code == ExitCode.COLLECTION_FAILED
-    assert isinstance(session.collection_reports[0].exc_info[1], ValueError)
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == ExitCode.CONFIGURATION_FAILED
+    assert "a1  is not a valid Python name" in result.output
 
 
 @pytest.mark.end_to_end

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -326,7 +326,8 @@ def test_selecting_task_with_marker_should_run_predecessor(runner, tmp_path):
     """
     tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
-    result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
+    with pytest.warns(UserWarning, match="Unknown pytask.mark.wip"):
+        result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 
     assert result.exit_code == ExitCode.OK
     assert "2  Succeeded" in result.output
@@ -368,8 +369,27 @@ def test_selecting_task_with_marker_ignores_other_task(runner, tmp_path):
     """
     tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
-    result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
+    with pytest.warns(UserWarning, match="Unknown pytask.mark.wip"):
+        result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
 
     assert result.exit_code == ExitCode.OK
     assert "1  Succeeded" in result.output
     assert "1  Skipped" in result.output
+
+
+@pytest.mark.end_to_end
+def test_selecting_task_with_unknown_marker_raises_warning(runner, tmp_path):
+    source = """
+    import pytask
+
+    @pytask.mark.wip
+    def task_example():
+        pass
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    with pytest.warns(UserWarning, match="Unknown pytask.mark.wip"):
+        result = runner.invoke(cli, [tmp_path.as_posix(), "-m", "wip"])
+
+    assert result.exit_code == ExitCode.OK
+    assert "1  Succeeded" in result.output

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -50,17 +50,30 @@ def test_pytask_mark_name_starts_with_underscore():
 
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
-def test_ini_markers(tmp_path, config_name):
-    tmp_path.joinpath(config_name).write_text(
-        textwrap.dedent(
-            """
-            [pytask]
-            markers =
-                a1: this is a webtest marker
-                a2: this is a smoke marker
-            """
-        )
-    )
+def test_parse_markers(tmp_path, config_name):
+    ini = """
+    [pytask]
+    markers =
+        a1: this is a webtest marker
+        a2: this is a smoke marker
+    """
+    tmp_path.joinpath(config_name).write_text(textwrap.dedent(ini))
+
+    session = main({"paths": tmp_path})
+
+    assert session.exit_code == ExitCode.OK
+    assert "a1" in session.config["markers"]
+    assert "a2" in session.config["markers"]
+
+
+@pytest.mark.end_to_end
+def test_parse_markers_toml(tmp_path):
+    toml = """
+    [tool.pytask.ini_options.markers]
+    a1 = "this is a webtest marker"
+    a2 = "this is a smoke marker"
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(toml))
 
     session = main({"paths": tmp_path})
 
@@ -72,21 +85,33 @@ def test_ini_markers(tmp_path, config_name):
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
 def test_markers_command(tmp_path, runner, config_name):
+    ini = """
+    [pytask]
+    markers =
+        a1: this is a webtest marker
+        a2: this is a smoke marker
+        nodescription
+    """
     config_path = tmp_path.joinpath(config_name)
-    config_path.write_text(
-        textwrap.dedent(
-            """
-            [pytask]
-            markers =
-                a1: this is a webtest marker
-                a2: this is a smoke marker
-                nodescription
-            """
-        )
-    )
+    config_path.write_text(textwrap.dedent(ini))
 
     result = runner.invoke(cli, ["markers", "-c", config_path.as_posix()])
+    assert result.exit_code == ExitCode.OK
+    for out in ["pytask.mark.a1", "pytask.mark.a2", "pytask.mark.nodescription"]:
+        assert out in result.output
 
+
+@pytest.mark.end_to_end
+def test_markers_command_toml(tmp_path, runner):
+    ini = """
+    [tool.pytask.ini_options]
+    markers = ["a1", "a2", "nodescription"]
+    """
+    config_path = tmp_path.joinpath("pyproject.toml")
+    config_path.write_text(textwrap.dedent(ini))
+
+    result = runner.invoke(cli, ["markers", "-c", config_path.as_posix()])
+    assert result.exit_code == ExitCode.OK
     for out in ["pytask.mark.a1", "pytask.mark.a2", "pytask.mark.nodescription"]:
         assert out in result.output
 

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -126,7 +126,6 @@ def test_ini_markers_whitespace_toml(runner, tmp_path):
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.OK
     assert "1  Succeeded" in result.output
-    breakpoint()
 
 
 @pytest.mark.end_to_end

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -92,32 +92,41 @@ def test_markers_command(tmp_path, runner, config_name):
 
 
 @pytest.mark.end_to_end
-@pytest.mark.filterwarnings("ignore:Unknown pytask.mark.")
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
 def test_ini_markers_whitespace(runner, tmp_path, config_name):
     tmp_path.joinpath(config_name).write_text(
-        textwrap.dedent(
-            """
-            [pytask]
-            markers =
-                a1 : this is a whitespace marker
-            """
-        )
+        "[pytask]\nmarkers =\n  a1 : this is a whitespace marker"
     )
-    tmp_path.joinpath("task_module.py").write_text(
-        textwrap.dedent(
-            """
-            import pytask
-            @pytask.mark.a1
-            def test_markers():
-                assert True
-            """
-        )
-    )
+    source = """
+    import pytask
+    @pytask.mark.a1
+    def task_markers():
+        assert True
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
-    assert result.exit_code == ExitCode.CONFIGURATION_FAILED
-    assert "a1  is not a valid Python name" in result.output
+    assert result.exit_code == ExitCode.OK
+    assert "1  Succeeded" in result.output
+
+
+@pytest.mark.end_to_end
+def test_ini_markers_whitespace_toml(runner, tmp_path):
+    tmp_path.joinpath("pyproject.toml").write_text(
+        "[tool.pytask.ini_options]\nmarkers = {'a1 ' = 'this is a whitespace marker'}"
+    )
+    source = """
+    import pytask
+    @pytask.mark.a1
+    def task_markers():
+        assert True
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == ExitCode.OK
+    assert "1  Succeeded" in result.output
+    breakpoint()
 
 
 @pytest.mark.end_to_end

--- a/tests/test_mark_cli.py
+++ b/tests/test_mark_cli.py
@@ -27,18 +27,31 @@ def test_show_markers(runner):
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
 def test_markers_option(tmp_path, runner, config_name):
+    ini = """
+    [pytask]
+    markers =
+        a1: this is a webtest marker
+        a1some: another marker
+        nodescription
+    """
     config_path = tmp_path.joinpath(config_name)
-    config_path.write_text(
-        textwrap.dedent(
-            """
-            [pytask]
-            markers =
-                a1: this is a webtest marker
-                a1some: another marker
-                nodescription
-            """
-        )
-    )
+    config_path.write_text(textwrap.dedent(ini))
+
+    result = runner.invoke(cli, ["markers", "-c", config_path.as_posix()])
+
+    assert all(marker in result.output for marker in ["a1", "a1some", "nodescription"])
+
+
+@pytest.mark.end_to_end
+def test_markers_option_toml(tmp_path, runner):
+    toml = """
+    [tool.pytask.ini_options.markers]
+    a1 = "this is a webtest marker"
+    a1some = "another marker"
+    nodescription = ""
+    """
+    config_path = tmp_path.joinpath("pyproject.toml")
+    config_path.write_text(textwrap.dedent(toml))
 
     result = runner.invoke(cli, ["markers", "-c", config_path.as_posix()])
 
@@ -49,14 +62,23 @@ def test_markers_option(tmp_path, runner, config_name):
 @pytest.mark.parametrize("config_name", ["pytask.ini", "tox.ini", "setup.cfg"])
 @pytest.mark.parametrize("marker_name", ["lkasd alksds", "1kasd"])
 def test_marker_names(tmp_path, marker_name, config_name):
-    tmp_path.joinpath(config_name).write_text(
-        textwrap.dedent(
-            f"""
-            [pytask]
-            markers =
-                {marker_name}
-            """
-        )
-    )
+    ini = f"""
+    [pytask]
+    markers =
+        {marker_name}
+    """
+    tmp_path.joinpath(config_name).write_text(textwrap.dedent(ini))
+    session = main({"paths": tmp_path, "markers": True})
+    assert session.exit_code == ExitCode.CONFIGURATION_FAILED
+
+
+@pytest.mark.end_to_end
+@pytest.mark.parametrize("marker_name", ["lkasd alksds", "1kasd"])
+def test_marker_names_toml(tmp_path, marker_name):
+    toml = f"""
+    [tool.pytask.ini_options.markers]
+    markers = ['{marker_name}']
+    """
+    tmp_path.joinpath("pyproject.toml").write_text(textwrap.dedent(toml))
     session = main({"paths": tmp_path, "markers": True})
     assert session.exit_code == ExitCode.CONFIGURATION_FAILED

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import textwrap
+from pathlib import Path
 
 import pytest
 from _pytask.cli import cli
@@ -99,8 +100,10 @@ def test_export_of_profile(tmp_path, runner, export):
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
 
+    cwd = Path.cwd()
     os.chdir(tmp_path)
     result = runner.invoke(cli, ["profile", tmp_path.as_posix(), "--export", export])
+    os.chdir(cwd)
 
     assert result.exit_code == ExitCode.OK
     assert "Collected 1 task." in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ conda_deps =
     pony >=0.7.15
     pybaum
     rich
+    tomli >=1.0.0
+    tomli-w >=1.0.0
 
     # Optional and test dependencies
     graphviz


### PR DESCRIPTION
#### Changes

- Add support for `pyproject.toml` as the configuration file.
- Raise warnings for ini formats and show a copy-paste snippet to migrate to the new configuration file.
- Remove all `ini` examples from the documentation.