### PR TITLE
Don't display traceback with 'previous task failed' with verbose <= 1.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -5,7 +5,15 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask).
 
-## 0.2.3 - 2022-xx-xx
+## 0.2.4 - 2022-xx-xx
+
+- {pull}`279` enhances some tutorials with spell and grammar checking.
+- {pull}`282` updates the tox configuration.
+- {pull}`283` fixes an issue with coverage and tests using pexpect + `pdb.set_trace()`.
+- {pull}`285` implements that pytask does not show the traceback of tasks which are
+  skipped because its previous task failed. Fixes {issue}`284`.
+
+## 0.2.3 - 2022-05-30
 
 - {pull}`276` fixes `pytask clean` when git is not installed. Fixes {issue}`275`.
 - {pull}`277` ignores `DeprecationWarning` and `PendingDeprecationWarning` by default.

--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -250,7 +250,10 @@ def pytask_execute_log_end(session: Session, reports: list[ExecutionReport]) -> 
             console.print()
 
         for report in reports:
-            if report.outcome in (TaskOutcome.FAIL, TaskOutcome.SKIP_PREVIOUS_FAILED):
+            if report.outcome == TaskOutcome.FAIL or (
+                report.outcome == TaskOutcome.SKIP_PREVIOUS_FAILED
+                and session.config["verbose"] >= 2
+            ):
                 _print_errored_task_report(session, report)
 
     console.rule(style="dim")


### PR DESCRIPTION
#### Changes

Closes #284.
