### PR TITLE
FIX: determine graphiz output format from file extension

### DIFF
--- a/src/_pytask/graph.py
+++ b/src/_pytask/graph.py
@@ -262,4 +262,5 @@ def _write_graph(dag: nx.DiGraph, path: Path, layout: str) -> None:
     """Write the graph to disk."""
     path.parent.mkdir(exist_ok=True, parents=True)
     graph = nx.nx_agraph.to_agraph(dag)
-    graph.draw(path, prog=layout)
+    format_ = path.suffix[1:] if path.suffix else None
+    graph.draw(path, format=format_, prog=layout)


### PR DESCRIPTION
This is the behavior that _HELP_TEXT_OUTPUT says should happen.

Now if you use `--output-path dag.png`, you get a .png. This is useful to me
so I can embed the plot in my docs.

I considered adding a whole new `--format` CLI flag etc, but I
decided that was overkill. Could be added later if someone
really wants it.

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [x] Reference issues which can be closed due to this PR with "Closes #x".
- [x] Review whether the documentation needs to be updated.
- [x] Document PR in docs/changes.rst.
