### PR TITLE
Remove `.value` from `Node` protocol.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -25,6 +25,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
   implementing their own nodes.
 - {pull}`404` allows to use function returns to define task products.
 - {pull}`405` allows to match function returns to node annotations with prefix trees.
+- {pull}`406` removes `.value` from `Node` protocol.
 
 ## 0.3.2 - 2023-06-07
 

--- a/src/_pytask/node_protocols.py
+++ b/src/_pytask/node_protocols.py
@@ -29,8 +29,6 @@ class MetaNode(Protocol):
 class Node(MetaNode, Protocol):
     """Protocol for nodes."""
 
-    value: Any
-
     def load(self) -> Any:
         """Return the value of the node that will be injected into the task."""
         ...

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -106,12 +106,8 @@ class PathNode(Node):
 
     name: str = ""
     """Name of the node which makes it identifiable in the DAG."""
-    value: Path | None = None
-    """Value passed to the decorator which can be requested inside the function."""
-
-    @property
-    def path(self) -> Path:
-        return self.value
+    path: Path | None = None
+    """The path to the file."""
 
     def from_annot(self, value: Path) -> None:
         """Set path and if other attributes are not set, set sensible defaults."""
@@ -119,7 +115,7 @@ class PathNode(Node):
             raise TypeError("'value' must be a 'pathlib.Path'.")
         if not self.name:
             self.name = value.as_posix()
-        self.value = value
+        self.path = value
 
     @classmethod
     @functools.lru_cache
@@ -131,7 +127,7 @@ class PathNode(Node):
         """
         if not path.is_absolute():
             raise ValueError("Node must be instantiated from absolute path.")
-        return cls(name=path.as_posix(), value=path)
+        return cls(name=path.as_posix(), path=path)
 
     def state(self) -> str | None:
         """Calculate the state of the node.
@@ -145,7 +141,7 @@ class PathNode(Node):
 
     def load(self) -> Path:
         """Load the value."""
-        return self.value
+        return self.path
 
     def save(self, value: bytes | str) -> None:
         """Save strings or bytes to file."""

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from _pytask.node_protocols import MetaNode
 from _pytask.node_protocols import Node
+from _pytask.node_protocols import PPathNode
 from _pytask.tree_util import PyTree
 from _pytask.tree_util import tree_leaves
 from _pytask.tree_util import tree_structure
@@ -101,7 +102,7 @@ class Task(MetaNode):
 
 
 @define(kw_only=True)
-class PathNode(Node):
+class PathNode(PPathNode):
     """The class for a node which is a path."""
 
     name: str = ""

--- a/tests/test_collect_command.py
+++ b/tests/test_collect_command.py
@@ -385,10 +385,8 @@ def test_print_collected_tasks_with_nodes(capsys):
                 base_name="function",
                 path=Path("task_path.py"),
                 function=function,
-                depends_on={
-                    "depends_on": PathNode(name="in.txt", value=Path("in.txt"))
-                },
-                produces={0: PathNode(name="out.txt", value=Path("out.txt"))},
+                depends_on={"depends_on": PathNode(name="in.txt", path=Path("in.txt"))},
+                produces={0: PathNode(name="out.txt", path=Path("out.txt"))},
             )
         ]
     }


### PR DESCRIPTION
- Do not require .value for Node.
- to changes.

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [ ] Reference issues which can be closed due to this PR with "Closes #x".
- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.
