### PR TITLE
Catch objects pretending to be `PTask`.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - sqlalchemy >=1.4.36
   - tomli >=1.0.0
   - typing_extensions
+  - ibis-duckdb
 
   # Misc
   - deepdiff

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -41,6 +41,7 @@ from _pytask.reports import CollectionReport
 from _pytask.shared import find_duplicates
 from _pytask.task_utils import task as task_decorator
 from _pytask.typing import is_task_function
+from _pytask.typing import pretends_to_be_a_task
 from rich.text import Text
 
 if TYPE_CHECKING:
@@ -279,7 +280,9 @@ def pytask_collect_task(
             markers=markers,
             attributes={"collection_id": collection_id, "after": after},
         )
-    if isinstance(obj, PTask) and not inspect.isclass(obj):
+    if pretends_to_be_a_task(obj):
+        return None
+    if isinstance(obj, PTask):
         return obj
     return None
 

--- a/src/_pytask/mark_utils.py
+++ b/src/_pytask/mark_utils.py
@@ -5,7 +5,6 @@ The utility functions are stored here to be separate from the plugin.
 """
 from __future__ import annotations
 
-import inspect
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -22,7 +21,7 @@ def get_all_marks(obj_or_task: Any | PTask) -> list[Mark]:
     """Get all marks from a callable or task."""
     if pretends_to_be_a_task(obj_or_task):
         return []
-    if isinstance(obj_or_task, PTask) and not inspect.isclass(obj_or_task):
+    if isinstance(obj_or_task, PTask):
         return obj_or_task.markers
     obj = obj_or_task
     return obj.pytask_meta.markers if hasattr(obj, "pytask_meta") else []

--- a/src/_pytask/mark_utils.py
+++ b/src/_pytask/mark_utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from _pytask.models import CollectionMetadata
 from _pytask.node_protocols import PTask
+from _pytask.typing import pretends_to_be_a_task
 
 
 if TYPE_CHECKING:
@@ -19,12 +20,12 @@ if TYPE_CHECKING:
 
 def get_all_marks(obj_or_task: Any | PTask) -> list[Mark]:
     """Get all marks from a callable or task."""
+    if pretends_to_be_a_task(obj_or_task):
+        return []
     if isinstance(obj_or_task, PTask) and not inspect.isclass(obj_or_task):
-        marks = obj_or_task.markers
-    else:
-        obj = obj_or_task
-        marks = obj.pytask_meta.markers if hasattr(obj, "pytask_meta") else []
-    return marks
+        return obj_or_task.markers
+    obj = obj_or_task
+    return obj.pytask_meta.markers if hasattr(obj, "pytask_meta") else []
 
 
 def set_marks(obj_or_task: Any | PTask, marks: list[Mark]) -> Any | PTask:

--- a/src/_pytask/typing.py
+++ b/src/_pytask/typing.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
 import functools
+import inspect
 from enum import Enum
 from typing import Any
 from typing import Final
 from typing import Literal
 from typing import TYPE_CHECKING
 
+from _pytask.node_protocols import PTask
 from attrs import define
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
 
-__all__ = ["Product", "ProductType"]
+__all__ = [
+    "NoDefault",
+    "Product",
+    "ProductType",
+    "is_task_function",
+    "no_default",
+    "pretends_to_be_a_task",
+]
 
 
 @define(frozen=True)
@@ -30,6 +39,32 @@ def is_task_function(obj: Any) -> bool:
     return (callable(obj) and hasattr(obj, "__name__")) or (
         isinstance(obj, functools.partial) and hasattr(obj.func, "__name__")
     )
+
+
+def pretends_to_be_a_task(obj: Any) -> bool:
+    """Check if an object is really a :class:`~pytask.PTask`.
+
+    Some object are overwriting ``__getattr__`` and therefore any ``isinstance`` check
+    with our protocols will invetibly return ``True``.
+
+    This check goes one step further and checks whether the attributes have conforming
+    types.
+
+    See :issue:`507` for the initial bug report.
+
+    """
+    if not isinstance(obj, PTask):
+        return False
+
+    # Catches Task or TaskWithoutPath imported in a module.
+    if not inspect.isclass(obj):
+        return True
+
+    # Catches, for example, ``from ibis import _``, objects that overwrote
+    # ``__getattr__``.
+    if not isinstance(obj.markers, list):
+        return True
+    return False
 
 
 class _NoDefault(Enum):

--- a/src/_pytask/typing.py
+++ b/src/_pytask/typing.py
@@ -42,7 +42,7 @@ def is_task_function(obj: Any) -> bool:
 
 
 def pretends_to_be_a_task(obj: Any) -> bool:
-    """Check if an object is really a :class:`~pytask.PTask`.
+    """Check if an object pretends to be a :class:`~pytask.PTask`.
 
     Some object are overwriting ``__getattr__`` and therefore any ``isinstance`` check
     with our protocols will invetibly return ``True``.
@@ -57,7 +57,7 @@ def pretends_to_be_a_task(obj: Any) -> bool:
         return False
 
     # Catches Task or TaskWithoutPath imported in a module.
-    if not inspect.isclass(obj):
+    if inspect.isclass(obj):
         return True
 
     # Catches, for example, ``from ibis import _``, objects that overwrote

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -682,9 +682,23 @@ def test_scheduling_w_mixed_priorities(runner, tmp_path):
 
 
 @pytest.mark.end_to_end()
-def test_module_can_be_collected(runner, tmp_path):
+def test_module_with_task_classes_can_be_collected(runner, tmp_path):
     source = """
     from pytask import Task, TaskWithoutPath
+    """
+    tmp_path.joinpath("task_example.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+    assert result.exit_code == ExitCode.OK
+
+
+@pytest.mark.end_to_end()
+def test_module_with_getattr_overwrite_can_be_collected(runner, tmp_path):
+    source = """
+    class C:
+        def __getattr__(self, name):
+            return C()
+    c = C()
     """
     tmp_path.joinpath("task_example.py").write_text(textwrap.dedent(source))
 


### PR DESCRIPTION
- Catch objects pretending to be tasks.
- Catch objects pretending to be tasks.

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [ ] Reference issues which can be closed due to this PR with "Closes #x".
- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.
