### PR TITLE
CI: remove unneeded install of graphviz on ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
       - if: matrix.os == 'macos-latest'
         run: brew install graphviz
 
+      - if: matrix.os == 'windows-latest'
+        run: choco install graphviz
+
       # Unit, integration, and end-to-end tests.
 
       - name: Run unit tests and doctests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,6 @@ jobs:
       - if: matrix.os == 'macos-latest'
         run: brew install graphviz
 
-      - if: matrix.os == 'windows-latest'
-        run: choco install graphviz
-
       # Unit, integration, and end-to-end tests.
 
       - name: Run unit tests and doctests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
           allow-prereleases: true
       - run: pip install tox
 
-      - if: matrix.os == 'macos-latest'
-        run: brew install graphviz
+      # - if: matrix.os == 'macos-latest'
+      #   run: brew install graphviz
 
       # Unit, integration, and end-to-end tests.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,13 @@ jobs:
           allow-prereleases: true
       - run: pip install tox
 
-      # - if: matrix.os == 'macos-latest'
-      #   run: brew install graphviz
+      - if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install graphviz graphviz-dev
+
+      - if: matrix.os == 'macos-latest'
+        run: brew install graphviz
 
       # Unit, integration, and end-to-end tests.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,6 @@ jobs:
           allow-prereleases: true
       - run: pip install tox
 
-      - if: matrix.os == 'ubunut-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install graphviz graphviz-dev
-
       - if: matrix.os == 'macos-latest'
         run: brew install graphviz
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -5,6 +5,10 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask).
 
+## 0.4.5 - 2023-12-xx
+
+- {pull}`515` enables tests with graphviz in CI. Thanks to {user}`NickCrews`.
+
 ## 0.4.4 - 2023-12-04
 
 - {pull}`509` improves the documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ docs = [
 test = [
   "deepdiff",
   "pexpect",
-  "pygraphviz",
   "pytest",
   "pytest-cov",
   "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,15 @@ docs = [
   "sphinx-toolbox",
   "sphinxext-opengraph",
 ]
-test = ["pytest", "pytest-cov", "pytest-xdist", "syrupy", "deepdiff", "pexpect"]
+test = [
+  "deepdiff",
+  "pexpect",
+  "pygraphviz",
+  "pytest",
+  "pytest-cov",
+  "pytest-xdist",
+  "syrupy",
+]
 
 [project.urls]
 Changelog = "https://pytask-dev.readthedocs.io/en/stable/changes.html"

--- a/tests/test_dag_command.py
+++ b/tests/test_dag_command.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import sys
 import textwrap
 
@@ -19,23 +18,10 @@ else:
 
 # Test should run always on remote except on Windows and locally only with the package
 # installed.
-_TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (os.environ.get("CI"))
-
-
+_TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (
+    os.environ.get("CI") and sys.platform != "win32"
+)
 _GRAPH_LAYOUTS = ["neato", "dot", "fdp", "sfdp", "twopi", "circo"]
-
-
-_PARAMETRIZED_LAYOUTS = [
-    pytest.param(
-        layout,
-        marks=pytest.mark.skip(reason=f"{layout} not available")
-        if shutil.which(layout) is None
-        else [],
-    )
-    for layout in _GRAPH_LAYOUTS
-]
-
-
 _TEST_FORMATS = ["dot", "pdf", "png", "jpeg", "svg"]
 
 

--- a/tests/test_dag_command.py
+++ b/tests/test_dag_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 import textwrap
@@ -15,6 +16,12 @@ except ImportError:  # pragma: no cover
     _IS_PYGRAPHVIZ_INSTALLED = False
 else:
     _IS_PYGRAPHVIZ_INSTALLED = True
+
+# Test should run always on remote except on Windows and locally only with the package
+# installed.
+_TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (
+    os.environ.get("CI") and sys.platform != "win32"
+)
 
 _GRAPH_LAYOUTS = ["neato", "dot", "fdp", "sfdp", "twopi", "circo"]
 
@@ -34,7 +41,7 @@ _TEST_FORMATS = ["dot", "pdf", "png", "jpeg", "svg"]
 
 
 @pytest.mark.end_to_end()
-@pytest.mark.skipif(not _IS_PYGRAPHVIZ_INSTALLED, reason="pygraphviz is required")
+@pytest.mark.skipif(not _TEST_SHOULD_RUN, reason="pygraphviz is required")
 @pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
 @pytest.mark.parametrize("rankdir", ["LR"])
@@ -70,7 +77,7 @@ def test_create_graph_via_cli(tmp_path, runner, format_, layout, rankdir):
 
 
 @pytest.mark.end_to_end()
-@pytest.mark.skipif(not _IS_PYGRAPHVIZ_INSTALLED, reason="pygraphviz is required")
+@pytest.mark.skipif(not _TEST_SHOULD_RUN, reason="pygraphviz is required")
 @pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
 @pytest.mark.parametrize("rankdir", [_RankDirection.LR.value, _RankDirection.TB])

--- a/tests/test_dag_command.py
+++ b/tests/test_dag_command.py
@@ -19,9 +19,7 @@ else:
 
 # Test should run always on remote except on Windows and locally only with the package
 # installed.
-_TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (
-    os.environ.get("CI") and sys.platform != "win32"
-)
+_TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (os.environ.get("CI"))
 
 
 _GRAPH_LAYOUTS = ["neato", "dot", "fdp", "sfdp", "twopi", "circo"]

--- a/tests/test_dag_command.py
+++ b/tests/test_dag_command.py
@@ -23,6 +23,7 @@ _TEST_SHOULD_RUN = _IS_PYGRAPHVIZ_INSTALLED or (
     os.environ.get("CI") and sys.platform != "win32"
 )
 
+
 _GRAPH_LAYOUTS = ["neato", "dot", "fdp", "sfdp", "twopi", "circo"]
 
 
@@ -42,7 +43,7 @@ _TEST_FORMATS = ["dot", "pdf", "png", "jpeg", "svg"]
 
 @pytest.mark.end_to_end()
 @pytest.mark.skipif(not _TEST_SHOULD_RUN, reason="pygraphviz is required")
-@pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
+@pytest.mark.parametrize("layout", _GRAPH_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
 @pytest.mark.parametrize("rankdir", ["LR"])
 def test_create_graph_via_cli(tmp_path, runner, format_, layout, rankdir):
@@ -78,7 +79,7 @@ def test_create_graph_via_cli(tmp_path, runner, format_, layout, rankdir):
 
 @pytest.mark.end_to_end()
 @pytest.mark.skipif(not _TEST_SHOULD_RUN, reason="pygraphviz is required")
-@pytest.mark.parametrize("layout", _PARAMETRIZED_LAYOUTS)
+@pytest.mark.parametrize("layout", _GRAPH_LAYOUTS)
 @pytest.mark.parametrize("format_", _TEST_FORMATS)
 @pytest.mark.parametrize("rankdir", [_RankDirection.LR.value, _RankDirection.TB])
 def test_create_graph_via_task(tmp_path, runner, format_, layout, rankdir):

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,15 @@ envlist = pytest
 [testenv]
 passenv = CI
 usedevelop = true
+platform =
+    linux: linux
+    macos: darwin
+    windows: win32
 
 [testenv:pytest]
 extras = test
+deps =
+    linux, macos: pygraphviz
 
 commands =
     pytest {posargs} -vv

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = pytest
+passenv = CI
 
 [testenv]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,9 @@ envlist = pytest
 [testenv]
 passenv = CI
 usedevelop = true
-platform =
-    linux: linux
-    macos: darwin
-    windows: win32
 
 [testenv:pytest]
 extras = test
-deps =
-    linux, macos: pygraphviz
 
 commands =
     pytest {posargs} -vv

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,11 @@ envlist = pytest
 [testenv]
 passenv = CI
 usedevelop = true
-platform =
-    linux: linux
-    macos: darwin
-    windows: win32
 
 [testenv:pytest]
 extras = test
 deps =
-    linux, macos: pygraphviz
+    pygraphviz;platform_system != "Windows"
 
 commands =
     pytest {posargs} -vv

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = pytest
-passenv = CI
 
 [testenv]
+passenv = CI
 usedevelop = true
 platform =
     linux: linux


### PR DESCRIPTION
There was a typo of `ubunut` so this
blockw as never getting run.
See https://github.com/pytask-dev/pytask/actions/runs/7092233325/job/19303082025
Guess it wasn't needed!

Does this mean the macos block can get deleted too?

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [x] Reference issues which can be closed due to this PR with "Closes #x".
- [x] Review whether the documentation needs to be updated.
- [x] Document PR in docs/changes.rst.
