### PR TITLE
use caller's module as ID for task in `task()`

### DIFF
--- a/src/_pytask/task_utils.py
+++ b/src/_pytask/task_utils.py
@@ -121,7 +121,8 @@ def task(
         # Based on https://stackoverflow.com/questions/1095543/get-name-of-calling-functions-module-in-python  # noqa: E501
         frm = inspect.stack()[1]
         task_module = inspect.getmodule(frm.frame)
-        COLLECTED_TASKS[task_module.__file__].append(unwrapped)
+        task_path = Path(task_module.__file__)
+        COLLECTED_TASKS[task_path].append(unwrapped)
 
         return unwrapped
 

--- a/src/_pytask/task_utils.py
+++ b/src/_pytask/task_utils.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 import inspect
 from collections import defaultdict
 from typing import Any
-from typing import Callable, TYPE_CHECKING
+from typing import Callable
 
 import attrs
 from _pytask.mark import Mark
 from _pytask.models import CollectionMetadata
 from _pytask.shared import find_duplicates
 from _pytask.typing import is_task_function
+from pathlib import Path
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 __all__ = [

--- a/src/_pytask/task_utils.py
+++ b/src/_pytask/task_utils.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 
 import inspect
 from collections import defaultdict
-from pathlib import Path
 from typing import Any
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
 import attrs
 from _pytask.mark import Mark
 from _pytask.models import CollectionMetadata
 from _pytask.shared import find_duplicates
 from _pytask.typing import is_task_function
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 __all__ = [


### PR DESCRIPTION
Closes #513

I didn't add any tests yet until I got confirmation this
is the right direction.

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [ ] Reference issues which can be closed due to this PR with "Closes #x".
- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.
