### PR TITLE
Fix type hints for `Task.execute()` and `TaskWithoutPath.execute()`.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -5,6 +5,11 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask).
 
+## 0.4.6
+
+- {pull}`548` fixes the type hints for {meth}`~pytask.Task.execute` and
+  {meth}`~pytask.TaskWithoutPath.execute`. Thanks to {user}`Ostheer`.
+
 ## 0.4.5 - 2024-01-09
 
 - {pull}`515` enables tests with graphviz in CI. Thanks to {user}`NickCrews`.

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -80,7 +80,7 @@ class TaskWithoutPath(PTask):
         else:
             return hashlib.sha256(source.encode()).hexdigest()
 
-    def execute(self, **kwargs: Any) -> None:
+    def execute(self, **kwargs: Any) -> Any:
         """Execute the task."""
         return self.function(**kwargs)
 
@@ -140,7 +140,7 @@ class Task(PTaskWithPath):
             return hash_path(self.path, modification_time)
         return None
 
-    def execute(self, **kwargs: Any) -> None:
+    def execute(self, **kwargs: Any) -> Any:
         """Execute the task."""
         return self.function(**kwargs)
 


### PR DESCRIPTION
Related to #547.