### PR TITLE
Fix path in "Node is dir" error message

### DIFF
--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -444,7 +444,7 @@ def pytask_collect_node(session: Session, path: Path, node_info: NodeInfo) -> PN
         name = shorten_path(node, session.config["paths"] or (session.config["root"],))
 
         if isinstance(node, Path) and node.is_dir():
-            raise ValueError(_TEMPLATE_ERROR_DIRECTORY.format(path=path))
+            raise ValueError(_TEMPLATE_ERROR_DIRECTORY.format(path=node))
 
         return PathNode(name=name, path=node)
 


### PR DESCRIPTION
The error message currently displays the path to the source file of the task. This fixes it to be the path of the node being considered.
