### PR TITLE
Skip collection of `MarkGenerator` when using `from pytask import mark`.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -5,6 +5,11 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask).
 
+## 0.4.6 - 2024-03-13
+
+- {pull}`575` fixes accidentally collecting `pytask.MarkGenerator` when using
+  `from pytask import mark`.
+
 ## 0.4.5 - 2024-01-09
 
 - {pull}`515` enables tests with graphviz in CI. Thanks to {user}`NickCrews`.

--- a/src/_pytask/collect.py
+++ b/src/_pytask/collect.py
@@ -21,6 +21,7 @@ from _pytask.console import create_summary_panel
 from _pytask.console import get_file
 from _pytask.exceptions import CollectionError
 from _pytask.exceptions import NodeNotCollectedError
+from _pytask.mark import MarkGenerator
 from _pytask.mark_utils import get_all_marks
 from _pytask.mark_utils import has_mark
 from _pytask.node_protocols import PNode
@@ -235,6 +236,10 @@ def _is_filtered_object(obj: Any) -> bool:
     See :issue:`507`.
 
     """
+    # Filter :class:`pytask.mark.MarkGenerator` which can raise errors on some marks.
+    if isinstance(obj, MarkGenerator):
+        return True
+
     # Filter :class:`pytask.Task` and :class:`pytask.TaskWithoutPath` objects.
     if isinstance(obj, PTask) and inspect.isclass(obj):
         return True

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -692,6 +692,7 @@ def test_module_can_be_collected(runner, tmp_path):
 
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.OK
+    assert "attr_that_definitely_does_not_exist" not in result.output
 
 
 @pytest.mark.end_to_end()


### PR DESCRIPTION
- Prevent collecting MarkGenerator.
- to changes.

#### Changes

Provide a description and/or bullet points to describe the changes in this PR.

#### Todo

- [ ] Reference issues which can be closed due to this PR with "Closes #x".
- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.
