### PR TITLE
Fix interaction with `--pdb`, `--trace` and tasks that return.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -23,6 +23,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 - {pull}`571` removes redundant calls to `PNode.state()` which causes a high penalty for
   remote files.
 - {pull}`573` removes the `pytask_execute_create_scheduler` hook.
+- {pull}`579` fixes an interaction with `--pdb` and `--trace` and task that return. The
+  debugging modes swallowed the return and `None` was returned. Closes {issue}`574`.
 
 ## 0.4.6 - 2024-03-13
 

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -332,7 +332,7 @@ def wrap_function_for_post_mortem_debugging(session: Session, task: PTask) -> No
         capman = session.config["pm"].get_plugin("capturemanager")
         live_manager = session.config["pm"].get_plugin("live_manager")
         try:
-            task_function(*args, **kwargs)
+            return task_function(*args, **kwargs)
 
         except Exception:
             # Order is important! Pausing the live object before the capturemanager
@@ -413,10 +413,12 @@ def wrap_function_for_tracing(session: Session, task: PTask) -> None:
             console.rule("Captured stderr", style="default")
             console.print(err)
 
-        _pdb.runcall(task_function, *args, **kwargs)
+        out = _pdb.runcall(task_function, *args, **kwargs)
 
         live_manager.resume()
         capman.resume()
+
+        return out
 
     task.function = wrapper
 

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -489,6 +489,8 @@ def test_set_trace_is_returned_after_pytask_finishes(tmp_path):
 
 
 @pytest.mark.end_to_end()
+@pytest.mark.skipif(not IS_PEXPECT_INSTALLED, reason="pexpect is not installed.")
+@pytest.mark.skipif(sys.platform == "win32", reason="pexpect cannot spawn on Windows.")
 def test_pdb_with_task_that_returns(tmp_path, runner):
     source = """
     from typing_extensions import Annotated
@@ -505,6 +507,8 @@ def test_pdb_with_task_that_returns(tmp_path, runner):
 
 
 @pytest.mark.end_to_end()
+@pytest.mark.skipif(not IS_PEXPECT_INSTALLED, reason="pexpect is not installed.")
+@pytest.mark.skipif(sys.platform == "win32", reason="pexpect cannot spawn on Windows.")
 def test_trace_with_task_that_returns(tmp_path):
     source = """
     from typing_extensions import Annotated


### PR DESCRIPTION
Closes #574.