### PR TITLE
Improve documentation for data catalogs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tests/test_jupyter/*.txt
 .pytest_cache
 .ruff_cache
 .venv
+docs/jupyter_execute

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -47,6 +47,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 - {pull}`603` fixes an example in the documentation about capturing warnings.
 - {pull}`604` fixes some examples with `PythonNode`s in the documentation.
 - {pull}`605` improves checks and CI.
+- {pull}`606` improves the documentation for data catalogs.
 
 ## 0.4.7 - 2024-03-19
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,8 +51,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_click",
     "sphinx_toolbox.more_autodoc.autoprotocol",
-    "nbsphinx",
-    "myst_parser",
+    "myst_nb",
     "sphinx_design",
 ]
 

--- a/docs/source/how_to_guides/bp_scaling_tasks.md
+++ b/docs/source/how_to_guides/bp_scaling_tasks.md
@@ -39,9 +39,6 @@ my_project
 │           ├────config.py
 │           └────task_estimate_models.py
 │
-│
-├───setup.py
-│
 ├───.pytask
 │   └────...
 │

--- a/docs/source/how_to_guides/the_data_catalog.md
+++ b/docs/source/how_to_guides/the_data_catalog.md
@@ -1,9 +1,8 @@
 # The `DataCatalog` - Revisited
 
-An introduction to the data catalog can be found in the
-[tutorial](../tutorials/using_a_data_catalog.md).
-
-This guide explains some details that were left out of the tutorial.
+This guide explains more details about the {class}`~pytask.DataCatalog` that were left
+out of the [tutorial](../tutorials/using_a_data_catalog.md). Please, read the tutorial
+for a basic understanding.
 
 ## Changing the default node
 
@@ -20,18 +19,18 @@ from pytask import PythonNode
 data_catalog = DataCatalog(default_node=PythonNode)
 ```
 
-Or, learn to write your own node by reading {doc}`writing_custom_nodes`.
+Or, learn to write your node by reading {doc}`writing_custom_nodes`.
 
-Here, is an example for a `PickleNode` that uses cloudpickle instead of the normal
-`pickle` module.
+Here, is an example for a {class}`~pytask.PickleNode` that uses cloudpickle instead of
+the normal {mod}`pickle` module.
 
 ```{literalinclude} ../../../docs_src/how_to_guides/the_data_catalog.py
 ```
 
 ## Changing the name and the default path
 
-By default, the data catalogs store their data in a directory `.pytask/data_catalogs`.
-If you use a `pyproject.toml` with a `[tool.pytask.ini_options]` section, then the
+By default, data catalogs store their data in a directory `.pytask/data_catalogs`. If
+you use a `pyproject.toml` with a `[tool.pytask.ini_options]` section, then the
 `.pytask` folder is in the same folder as the configuration file.
 
 The default name for a catalog is `"default"` and so you will find its data in

--- a/docs/source/how_to_guides/the_data_catalog.md
+++ b/docs/source/how_to_guides/the_data_catalog.md
@@ -14,6 +14,7 @@ For example, use the {class}`~pytask.PythonNode` as the default.
 
 ```python
 from pytask import PythonNode
+from pytask import DataCatalog
 
 
 data_catalog = DataCatalog(default_node=PythonNode)
@@ -38,6 +39,9 @@ The default name for a catalog is `"default"` and so you will find its data in
 `"data_management"`, you will find the data in `.pytask/data_catalogs/data_management`.
 
 ```python
+from pytask import DataCatalog
+
+
 data_catalog = DataCatalog(name="data_management")
 ```
 
@@ -51,6 +55,7 @@ data catalog is defined in `.data`.
 
 ```python
 from pathlib import Path
+from pytask import DataCatalog
 
 
 data_catalog = DataCatalog(path=Path(__file__).parent / ".data")
@@ -58,14 +63,15 @@ data_catalog = DataCatalog(path=Path(__file__).parent / ".data")
 
 ## Multiple data catalogs
 
-You can use multiple data catalogs when you want to separate your datasets across
-multiple catalogs or when you want to use the same names multiple times (although it is
-not recommended!).
+You can use multiple data catalogs when you want to separate your datasets or to avoid
+name collisions of data catalog entries.
 
 Make sure you assign different names to the data catalogs so that their data is stored
 in different directories.
 
 ```python
+from pytask import DataCatalog
+
 # Stored in .pytask/data_catalog/a
 data_catalog_a = DataCatalog(name="a")
 
@@ -74,3 +80,53 @@ data_catalog_b = DataCatalog(name="b")
 ```
 
 Or, use different paths as explained above.
+
+## Nested data catalogs
+
+Name collisions can also occur when you are using multiple levels of repetitions, for
+example, when you are fitting multiple models to multiple data sets.
+
+You can structure your data catalogs like this.
+
+```python
+from pytask import DataCatalog
+
+
+MODEL_NAMES = ("ols", "logistic_regression")
+DATA_NAMES = ("data_1", "data_2")
+
+
+nested_data_catalogs = {
+    model_name: {
+        data_name: DataCatalog(name=f"{model_name}-{data_name}")
+        for data_name in DATA_NAMES
+    }
+    for model_name in MODEL_NAMES
+}
+```
+
+The task could look like this.
+
+```python
+from pathlib import Path
+from pytask import task
+from typing_extensions import Annotated
+
+from my_project.config import DATA_NAMES
+from my_project.config import MODEL_NAMES
+from my_project.config import nested_data_catalogs
+
+
+for model_name in MODEL_NAMES:
+    for data_name in DATA_NAMES:
+
+        @task
+        def fit_model(
+            path: Path = Path("...", data_name)
+        ) -> Annotated[
+            Any, nested_data_catalogs[model_name][data_name]["fitted_model"]
+        ]:
+            data = ...
+            fitted_model = ...
+            return fitted_model
+```

--- a/docs/source/how_to_guides/the_data_catalog.md
+++ b/docs/source/how_to_guides/the_data_catalog.md
@@ -41,6 +41,10 @@ The default name for a catalog is `"default"` and so you will find its data in
 data_catalog = DataCatalog(name="data_management")
 ```
 
+```{note}
+The name of a data catalog is restricted to letters, numbers, hyphens and underscores.
+```
+
 You can also change the path where the data catalogs will be stored by changing the
 `path` attribute. Here, we store the data catalog's data next to the module where the
 data catalog is defined in `.data`.

--- a/docs/source/reference_guides/api.md
+++ b/docs/source/reference_guides/api.md
@@ -327,6 +327,9 @@ resolution and execution.
 
     An indicator to mark arguments of tasks as products.
 
+    >>> from pathlib import Path
+    >>> from pytask import Product
+    >>> from typing_extensions import Annotated
     >>> def task_example(path: Annotated[Path, Product]) -> None:
     ...     path.write_text("Hello, World!")
 

--- a/docs/source/reference_guides/api.md
+++ b/docs/source/reference_guides/api.md
@@ -228,7 +228,9 @@ Task are currently represented by the following classes:
 
 ```{eval-rst}
 .. autoclass:: pytask.Task
+   :members:
 .. autoclass:: pytask.TaskWithoutPath
+   :members:
 ```
 
 Currently, there are no different types of tasks since changing the `.function`

--- a/docs_src/tutorials/using_a_data_catalog_4.py
+++ b/docs_src/tutorials/using_a_data_catalog_4.py
@@ -10,4 +10,3 @@ data_catalog = DataCatalog()
 
 # Use either a relative or a absolute path.
 data_catalog.add("csv", Path("file.csv"))
-data_catalog.add("transformed_csv", BLD / "file.pkl")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docs = [
     "ipython",
     "matplotlib",
     "myst-parser",
-    "nbsphinx",
+    "myst-nb",
     "sphinx",
     "sphinx-click",
     "sphinx-copybutton",
@@ -91,6 +91,10 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = ["tox-uv>=1.7.0"]
+
+[tool.rye.scripts]
+clean-docs = { cmd = "rm -rf docs/build" }
+build-docs = { cmd = "sphinx-build -b html docs/source docs/build" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/_pytask/_version.py"

--- a/src/_pytask/data_catalog.py
+++ b/src/_pytask/data_catalog.py
@@ -91,10 +91,8 @@ class DataCatalog:
             self.add(name)
         return self.entries[name]
 
-    def add(self, name: str, node: PNode | PProvisionalNode | None = None) -> None:
+    def add(self, name: str, node: PNode | PProvisionalNode | Any = None) -> None:
         """Add an entry to the data catalog."""
-        assert isinstance(self.path, Path)
-
         if not isinstance(name, str):
             msg = "The name of a catalog entry must be a string."
             raise TypeError(msg)
@@ -107,7 +105,7 @@ class DataCatalog:
                 )
             else:
                 self.entries[name] = self.default_node(name=name)  # type: ignore[call-arg]
-            self.path.joinpath(f"{filename}-node.pkl").write_bytes(
+            self.path.joinpath(f"{filename}-node.pkl").write_bytes(  # type: ignore[union-attr]
                 pickle.dumps(self.entries[name])
             )
         elif isinstance(node, (PNode, PProvisionalNode)):

--- a/src/_pytask/data_catalog.py
+++ b/src/_pytask/data_catalog.py
@@ -59,7 +59,6 @@ class DataCatalog:
     """
 
     default_node: type[PNode] = PickleNode
-    entries: dict[str, PNode | PProvisionalNode] = field(factory=dict)
     name: str = field(default="default")
     path: Path | None = None
     _entries: dict[str, PNode | PProvisionalNode] = field(factory=dict)

--- a/src/_pytask/data_catalog.py
+++ b/src/_pytask/data_catalog.py
@@ -48,8 +48,9 @@ class DataCatalog:
         :class:`~pytask.PickleNode` is used to serialize any Python object with the
         :mod:`pickle` module.
     name
-        The name of the data catalog. Use it when you are working with multiple data
-        catalogs that store data under the same keys.
+        The name of the data catalog which can only contain letters, numbers, hyphens
+        and underscores. Use it when you are working with multiple data catalogs to
+        store data in different locations.
     path
         A path where automatically created files are stored. By default, it will be
         ``.pytask/data_catalogs/default``.

--- a/src/_pytask/data_catalog.py
+++ b/src/_pytask/data_catalog.py
@@ -75,7 +75,7 @@ class DataCatalog:
         self.path.mkdir(parents=True, exist_ok=True)
 
         # Initialize the data catalog with persisted nodes from previous runs.
-        for path in self.path.glob("*-node.pkl"):  # type: ignore[union-attr]
+        for path in self.path.glob("*-node.pkl"):
             node = pickle.loads(path.read_bytes())  # noqa: S301
             self._entries[node.name] = node
 

--- a/src/_pytask/data_catalog.py
+++ b/src/_pytask/data_catalog.py
@@ -47,9 +47,6 @@ class DataCatalog:
         A default node for loading and saving values. By default,
         :class:`~pytask.PickleNode` is used to serialize any Python object with the
         :mod:`pickle` module.
-    entries
-        A collection of entries in the catalog. Entries can be :class:`~pytask.PNode` or
-        a :class:`DataCatalog` itself for nesting catalogs.
     name
         The name of the data catalog. Use it when you are working with multiple data
         catalogs that store data under the same keys.
@@ -60,13 +57,13 @@ class DataCatalog:
     """
 
     default_node: type[PNode] = PickleNode
-    entries: dict[str, PNode | PProvisionalNode] = field(factory=dict)
     name: str = "default"
     path: Path | None = None
+    _entries: dict[str, PNode | PProvisionalNode] = field(factory=dict)
+    _instance_path: Path = field(factory=_get_parent_path_of_data_catalog_module)
     _session_config: dict[str, Any] = field(
         factory=lambda *x: {"check_casing_of_paths": True}  # noqa: ARG005
     )
-    _instance_path: Path = field(factory=_get_parent_path_of_data_catalog_module)
 
     def __attrs_post_init__(self) -> None:
         root_path, _ = find_project_root_and_config((self._instance_path,))
@@ -77,19 +74,16 @@ class DataCatalog:
 
         self.path.mkdir(parents=True, exist_ok=True)
 
-        self._initialize()
-
-    def _initialize(self) -> None:
-        """Initialize the data catalog with persisted nodes from previous runs."""
+        # Initialize the data catalog with persisted nodes from previous runs.
         for path in self.path.glob("*-node.pkl"):  # type: ignore[union-attr]
             node = pickle.loads(path.read_bytes())  # noqa: S301
-            self.entries[node.name] = node
+            self._entries[node.name] = node
 
     def __getitem__(self, name: str) -> PNode | PProvisionalNode:
         """Allow to access entries with the squared brackets syntax."""
-        if name not in self.entries:
+        if name not in self._entries:
             self.add(name)
-        return self.entries[name]
+        return self._entries[name]
 
     def add(self, name: str, node: PNode | PProvisionalNode | Any = None) -> None:
         """Add an entry to the data catalog."""
@@ -100,16 +94,16 @@ class DataCatalog:
         if node is None:
             filename = hashlib.sha256(name.encode()).hexdigest()
             if isinstance(self.default_node, PPathNode):
-                self.entries[name] = self.default_node(
+                self._entries[name] = self.default_node(
                     name=name, path=self.path / f"{filename}.pkl"
                 )
             else:
-                self.entries[name] = self.default_node(name=name)  # type: ignore[call-arg]
+                self._entries[name] = self.default_node(name=name)  # type: ignore[call-arg]
             self.path.joinpath(f"{filename}-node.pkl").write_bytes(  # type: ignore[union-attr]
-                pickle.dumps(self.entries[name])
+                pickle.dumps(self._entries[name])
             )
         elif isinstance(node, (PNode, PProvisionalNode)):
-            self.entries[name] = node
+            self._entries[name] = node
         else:
             # Acquire the latest pluginmanager.
             session = Session(config=self._session_config, hook=storage.get().hook)
@@ -123,4 +117,4 @@ class DataCatalog:
             if collected_node is None:  # pragma: no cover
                 msg = f"{node!r} cannot be parsed."
                 raise NodeNotCollectedError(msg)
-            self.entries[name] = collected_node
+            self._entries[name] = collected_node

--- a/src/_pytask/nodes.py
+++ b/src/_pytask/nodes.py
@@ -226,6 +226,7 @@ class PythonNode(PNode):
     own hashing function. For example, from the :mod:`deepdiff` library.
 
     >>> from deepdiff import DeepHash
+    >>> from pytask import PythonNode
     >>> node = PythonNode(name="node", value={"a": 1}, hash=lambda x: DeepHash(x)[x])
 
     .. warning:: Hashing big objects can require some time.

--- a/src/_pytask/outcomes.py
+++ b/src/_pytask/outcomes.py
@@ -174,7 +174,7 @@ def count_outcomes(
 
     Examples
     --------
-    >>> from _pytask.outcomes import CollectionOutcome, TaskOutcome
+    >>> from _pytask.outcomes import CollectionOutcome, TaskOutcome, count_outcomes
     >>> count_outcomes([], CollectionOutcome)
     {<CollectionOutcome.SUCCESS: 1>: 0, <CollectionOutcome.FAIL: 2>: 0}
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ package = editable
 [testenv:docs]
 extras = docs, test
 commands =
-    - sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs/source docs/build/html
+    sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs/source docs/build/html
     - sphinx-build -n -T -b doctest -d {envtmpdir}/doctrees docs/source docs/build/html
 
 [testenv:typing]


### PR DESCRIPTION
Closes #572.

- [x] ~~Document nested data catalogs.~~ Not relevant enough.
- [x] `entries` vs `add`. Entries shouldnt be used at all. Made it private for v0.5.