### PR TITLE
tests: make coiled an optional import

### DIFF
--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -4,7 +4,6 @@ import functools
 import textwrap
 from contextlib import ExitStack as does_not_raise  # noqa: N813
 
-import coiled
 import pytest
 from _pytask.shared import convert_to_enum
 from _pytask.shared import find_duplicates
@@ -75,6 +74,14 @@ def test_unwrap_task_function():
 
     decorated = decorator(task)
     assert unwrap_task_function(decorated) is task
+
+
+@pytest.mark.unit()
+def test_no_unwrap_coiled():
+    coiled = pytest.importorskip("coiled")
+
+    def task():
+        pass
 
     coiled_decorated = coiled.function()(task)
     assert unwrap_task_function(coiled_decorated) is coiled_decorated


### PR DESCRIPTION
The python package `coiled` has a non-free license, it lacks any license at all from the looks of it. This PR skips testing `coiled` if it is not installed making it easier to package for systems which care about only packaging free software.

#### Changes

Splits `test_unwrap_task_function` into `test_unwrap_task_function` and `test_no_unwrap_coiled` the latter of which is skipped if coiled is not installed.

#### Todo

- [x] Reference issues which can be closed due to this PR with "Closes #x".
- [x] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.

I could not find the file `docs/changes.rst`.
