### PR TITLE
tests: remove dependence on root folder name

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -153,7 +153,7 @@ _ROOT = Path.cwd()
             PathNode.from_path(_ROOT.joinpath("src/module.py")),
             [_ROOT.joinpath("alternative_src")],
             does_not_raise(),
-            Text("pytask/src/module.py"),
+            Text(f"{_ROOT.name}/src/module.py"),
             id="Common path found for PathNode not in 'paths' and 'paths'",
         ),
         pytest.param(
@@ -174,7 +174,7 @@ _ROOT = Path.cwd()
             PythonNode(name=_ROOT.as_posix() + "/task_a.py::task_a::a", value=None),
             [_ROOT],
             does_not_raise(),
-            Text("pytask/task_a.py::task_a::a"),
+            Text(f"{_ROOT.name}/task_a.py::task_a::a"),
             id="PythonNode with automatically assigned name",
         ),
     ],


### PR DESCRIPTION
`test_reduce_node_name` assumes the root directory of the source code is called `pytask`. This may not be true for a variety of reasons.

#### Changes

Replaces the string `pytask` with `__ROOT.name` in the expected output for `test_reduce_node_name`.

#### Todo

- [x] Reference issues which can be closed due to this PR with "Closes #x".
- [x] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.

I could not find the file `docs/changes.rst`