### PR TITLE
Disable syntax highlighting for platform version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 - {pull}`703` fixes {issue}`701` by allowing `--capture tee-sys` again.
 - {pull}`704` adds the `--explain` flag to show why tasks would be executed. Closes {issue}`466`.
+- {pull}`706` disables syntax highlighting for platform version information in session header.
 
 ## 0.5.5 - 2025-07-25
 

--- a/docs/source/_static/md/capture.md
+++ b/docs/source/_static/md/capture.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 2 tasks.
 

--- a/docs/source/_static/md/clean-dry-run-directories.md
+++ b/docs/source/_static/md/clean-dry-run-directories.md
@@ -4,7 +4,7 @@
 
 $ pytask clean --directories
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/clean-dry-run.md
+++ b/docs/source/_static/md/clean-dry-run.md
@@ -4,7 +4,7 @@
 
 $ pytask clean
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/collect-nodes.md
+++ b/docs/source/_static/md/collect-nodes.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/collect.md
+++ b/docs/source/_static/md/collect.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/defining-dependencies-products.md
+++ b/docs/source/_static/md/defining-dependencies-products.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 2 task.
 

--- a/docs/source/_static/md/dry-run.md
+++ b/docs/source/_static/md/dry-run.md
@@ -4,7 +4,7 @@
 
 $ pytask --dry-run
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/explain.md
+++ b/docs/source/_static/md/explain.md
@@ -4,7 +4,7 @@
 
 $ pytask --explain
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: darwin -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.6</span>, pluggy <span style="color: var(--termynal-blue)">1.6.0</span>
+Platform: darwin -- Python 3.12.0, pytask 0.5.6, pluggy 1.6.0
 Root: /Users/pytask-dev/git/my_project
 Collected 3 tasks.
 

--- a/docs/source/_static/md/migrating-from-scripts-to-pytask.md
+++ b/docs/source/_static/md/migrating-from-scripts-to-pytask.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/pdb.md
+++ b/docs/source/_static/md/pdb.md
@@ -4,7 +4,7 @@
 
 $ pytask --pdb
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/persist-executed.md
+++ b/docs/source/_static/md/persist-executed.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/persist-persisted.md
+++ b/docs/source/_static/md/persist-persisted.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/persist-skipped.md
+++ b/docs/source/_static/md/persist-skipped.md
@@ -4,7 +4,7 @@
 
 $ pytask --verbose 2
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/profiling-tasks.md
+++ b/docs/source/_static/md/profiling-tasks.md
@@ -4,7 +4,7 @@
 
 $ pytask profile
 ───────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 18 task.
 

--- a/docs/source/_static/md/readme.md
+++ b/docs/source/_static/md/readme.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ──────────────────────────── Start pytask session ────────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/repeating-tasks.md
+++ b/docs/source/_static/md/repeating-tasks.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 10 task.
 

--- a/docs/source/_static/md/show-locals.md
+++ b/docs/source/_static/md/show-locals.md
@@ -4,7 +4,7 @@
 
 $ pytask --show-locals
 ──────────────────────────── Start pytask session ────────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/trace.md
+++ b/docs/source/_static/md/trace.md
@@ -4,7 +4,7 @@
 
 $ pytask --trace
 ──────────────────────────── Start pytask session ────────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/try-first.md
+++ b/docs/source/_static/md/try-first.md
@@ -4,7 +4,7 @@
 
 $ pytask -s
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 2 task.
 

--- a/docs/source/_static/md/try-last.md
+++ b/docs/source/_static/md/try-last.md
@@ -4,7 +4,7 @@
 
 $ pytask -s
 ────────────────────────── Start pytask session ────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 2 task.
 

--- a/docs/source/_static/md/warning.md
+++ b/docs/source/_static/md/warning.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/docs/source/_static/md/write-a-task.md
+++ b/docs/source/_static/md/write-a-task.md
@@ -4,7 +4,7 @@
 
 $ pytask
 ────────────────────────── Start pytask session ─────────────────────────
-Platform: win32 -- Python <span style="color: var(--termynal-blue)">3.12.0</span>, pytask <span style="color: var(--termynal-blue)">0.5.3</span>, pluggy <span style="color: var(--termynal-blue)">1.3.0</span>
+Platform: win32 -- Python 3.12.0, pytask 0.5.3, pluggy 1.3.0
 Root: C:\Users\pytask-dev\git\my_project
 Collected 1 task.
 

--- a/src/_pytask/logging.py
+++ b/src/_pytask/logging.py
@@ -66,7 +66,8 @@ def pytask_log_session_header(session: Session) -> None:
     console.rule("Start pytask session", style="default")
     console.print(
         f"Platform: {sys.platform} -- Python {platform.python_version()}, "
-        f"pytask {_pytask.__version__}, pluggy {pluggy.__version__}"
+        f"pytask {_pytask.__version__}, pluggy {pluggy.__version__}",
+        highlight=False,
     )
     console.print(f"Root: {session.config['root']}")
     if session.config["config"] is not None:


### PR DESCRIPTION
## Summary
- Add `highlight=False` to `console.print()` in session header to prevent version numbers from being colorized
- Remove span tags from Platform lines in documentation markdown files for consistency