### PR TITLE
Fix TypeError with Click Sentinel in Python 3.14

### DIFF
--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -92,12 +92,14 @@ def pytask_extend_command_line_interface(cli: click.Group) -> None:
             metavar="MARKER_EXPRESSION",
             type=str,
             help="Select tasks via marker expressions.",
+            default=None,
         ),
         click.Option(
             ["-k", "expression"],
             metavar="EXPRESSION",
             type=str,
             help="Select tasks via expressions on task ids.",
+            default=None,
         ),
     ]
     for command in ("build", "clean", "collect"):


### PR DESCRIPTION
# Fix TypeError with Click Sentinel in Python 3.14

Closes #722 

## Problem

When running pytask 0.5.6 with Python 3.14 and Click 8.3.1, users encounter:
```
TypeError: object of type 'Sentinel' has no len()
```

This occurs during dependency resolution when no `-k` or `-m` flags are provided.

## Root Cause

In Click 8.3.1, when a `click.Option` doesn't have an explicit `default` parameter, it uses `Sentinel.UNSET` (an enum) instead of `None`.

The code path:
1. `session.config["expression"]` retrieves `Sentinel.UNSET` when no `-k` flag is given
2. `select_by_keyword()` passes this to `Expression.compile_(keywordexpr)`
3. `Scanner.lex()` tries to call `len(input_)` on the Sentinel
4. TypeError is raised because Sentinel objects don't support `len()`

Stack trace shows error at:
```
_pytask/mark/expression.py:92 in lex
    while pos < len(input_):
```

## Solution

Add explicit `default=None` to both click.Option definitions in `src/_pytask/mark/__init__.py`:
- Line 95: `-m/--marker_expression`
- Line 102: `-k/--expression`

The existing `if not keywordexpr:` checks (lines 157, 212) already handle `None` correctly.

## Changes

- `src/_pytask/mark/__init__.py`: Added `default=None` to two click.Option definitions

## Testing

Tested with:
- Python 3.14.0
- Click 8.3.1
- pytask 0.5.6

**Before fix:**
```
TypeError: object of type 'Sentinel' has no len()
```

**After fix:**
```
✓ 1 Collected task
✓ 1 Succeeded (100.0%)
Succeeded in 0.03 seconds
```

Also verified:
- `-k expression` flag works correctly when provided
- `-m marker` flag works correctly when provided
- Tasks execute and produce expected output

## Compatibility

This fix maintains backward compatibility while adding support for:
- Python 3.14
- Click 8.3.1+

---

This is my first contribution to pytask. Happy to make any changes you'd like!
