### PR TITLE
Skip coiled on Python 3.14 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = [
     "pytest-xdist>=3.6.1",
     "syrupy>=4.5.0",
     "aiohttp>=3.11.0",                                                        # For HTTPPath tests.
-    "coiled>=1.42.0",
+    "coiled>=1.42.0; python_version < '3.14'",
     "pygraphviz>=1.12;platform_system=='Linux'",
 ]
 typing = ["ty>=0.0.8"]

--- a/uv.lock
+++ b/uv.lock
@@ -2697,7 +2697,7 @@ plugin-list = [
 test = [
     { name = "aiohttp" },
     { name = "cloudpickle" },
-    { name = "coiled" },
+    { name = "coiled", marker = "python_full_version < '3.14'" },
     { name = "deepdiff" },
     { name = "nbmake", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
     { name = "pexpect" },
@@ -2752,7 +2752,7 @@ plugin-list = [
 test = [
     { name = "aiohttp", specifier = ">=3.11.0" },
     { name = "cloudpickle", specifier = ">=3.0.0" },
-    { name = "coiled", specifier = ">=1.42.0" },
+    { name = "coiled", marker = "python_full_version < '3.14'", specifier = ">=1.42.0" },
     { name = "deepdiff", specifier = ">=7.0.0" },
     { name = "nbmake", marker = "python_full_version < '3.14' or sys_platform != 'win32'", specifier = ">=1.5.5" },
     { name = "pexpect", specifier = ">=4.9.0" },


### PR DESCRIPTION
Skip coiled for Python 3.14 in test dependencies to avoid upstream gilknocker packaging issue during CI dependency resolution.