### PR TITLE
Reset marker config during unconfigure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- [#868](https://github.com/pytask-dev/pytask/pull/868) resets the global marker
+  configuration during unconfigure so `--strict-markers` no longer leaks into later
+  marker access in the same process.
 - [#837](https://github.com/pytask-dev/pytask/pull/837) skips incremental live
   rendering on non-interactive output while preserving the final build table and
   live-manager lifecycle.

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -112,6 +112,12 @@ def pytask_parse_config(config: dict[str, Any]) -> None:
 
 
 @hookimpl
+def pytask_unconfigure() -> None:
+    """Reset marker state after pytask is done."""
+    MARK_GEN.config = None
+
+
+@hookimpl
 def pytask_post_parse(config: dict[str, Any]) -> None:
     config["markers"] = parse_markers(config["markers"])
 

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -355,6 +355,27 @@ def test_error_with_unknown_marker_and_strict(runner, tmp_path):
     assert "Unknown pytask.mark.unknown" in result.output
 
 
+@pytest.mark.filterwarnings("ignore:Unknown pytask\\.mark\\.foo")
+def test_strict_markers_do_not_leak_after_unconfigure(runner, tmp_path):
+    source = """
+    from pytask import mark
+
+    @mark.unknown
+    def task_write_text(): ...
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+    result = runner.invoke(cli, [tmp_path.as_posix(), "--strict-markers"])
+    assert result.exit_code == ExitCode.COLLECTION_FAILED
+
+    # If the strict config leaked through MARK_GEN.config, this unknown marker would
+    # raise instead of warning and returning a MarkDecorator.
+    md = pytask.mark.foo(1, "2", three=3)
+
+    assert md.name == "foo"
+    assert md.args == (1, "2")
+    assert md.kwargs == {"three": 3}
+
+
 @pytest.mark.parametrize("name", ["parametrize", "depends_on", "produces", "task"])
 def test_error_with_deprecated_markers(runner, tmp_path, name):
     source = f"""


### PR DESCRIPTION
## Summary

Reset the global marker generator configuration when pytask unconfigures so process-local strict marker settings cannot affect later marker access.

## Root Cause

`pytask_parse_config()` stores the active config on the singleton `MARK_GEN`. A run using `--strict-markers` left that config attached after `pytask_unconfigure()`, so later code in the same process could treat unknown markers as strict errors instead of warning.

## Changes

- Add a marker plugin `pytask_unconfigure()` hook that clears `MARK_GEN.config`.
- Add a regression test that runs a strict-marker failure before accessing an unknown marker through `pytask.mark`.
- Document the fix in `CHANGELOG.md`.

## Validation

```bash
uv run --group test pytest tests/test_mark.py::test_error_with_unknown_marker_and_strict tests/test_mark_structures.py::test_aliases tests/test_mark.py::test_strict_markers_do_not_leak_after_unconfigure -q
```
