### PR TITLE
fix(execution): catch BaseException from task code

### DIFF
--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -122,7 +122,7 @@ def pytask_execute_task_protocol(session: Session, task: PTask) -> ExecutionRepo
         short_exc_info = remove_traceback_from_exc_info(sys.exc_info())
         report = ExecutionReport.from_task_and_exception(task, short_exc_info)
         session.should_stop = True
-    except Exception:  # noqa: BLE001
+    except BaseException:  # noqa: BLE001
         report = ExecutionReport.from_task_and_exception(task, sys.exc_info())
     else:
         report = ExecutionReport.from_task(task)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -11,6 +11,7 @@ import textwrap
 import pytest
 
 import pytask
+from _pytask.mark import MARK_GEN
 from pytask import CaptureMethod
 from pytask import ExitCode
 from pytask import NodeNotFoundError
@@ -121,6 +122,45 @@ def test_node_not_found_in_task_setup(tmp_path):
     exc_info = report.exc_info
     assert exc_info is not None
     assert isinstance(exc_info[1], NodeNotFoundError)
+
+
+@pytest.mark.parametrize("exit_code", [0, 7])
+def test_system_exit_is_a_normal_task_failure(tmp_path, exit_code):
+    source = f"""
+    from pathlib import Path
+
+    def task_exits(produces=Path("upstream.txt")):
+        raise SystemExit({exit_code})
+
+    def task_descendant(
+        path=Path("upstream.txt"), produces=Path("descendant.txt")
+    ):
+        produces.write_text(path.read_text())
+
+    def task_unrelated(produces=Path("unrelated.txt")):
+        produces.write_text("unrelated")
+    """
+    tmp_path.joinpath("task_module.py").write_text(textwrap.dedent(source))
+
+    session = build(paths=tmp_path)
+
+    assert session.exit_code == ExitCode.FAILED
+    assert tmp_path.joinpath("unrelated.txt").read_text() == "unrelated"
+    assert not tmp_path.joinpath("descendant.txt").exists()
+    assert {report.outcome for report in session.execution_reports} == {
+        TaskOutcome.FAIL,
+        TaskOutcome.SKIP_PREVIOUS_FAILED,
+        TaskOutcome.SUCCESS,
+    }
+    failed_report = next(
+        report
+        for report in session.execution_reports
+        if report.outcome == TaskOutcome.FAIL
+    )
+    assert failed_report.exc_info is not None
+    assert isinstance(failed_report.exc_info[1], SystemExit)
+    assert failed_report.exc_info[1].code == exit_code
+    assert MARK_GEN.config is None
 
 
 def test_depends_on_and_produces_can_be_used_in_task(tmp_path):

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -191,8 +191,10 @@ def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -
     [
         (
             "foo or",
-            ("at column 7: expected not OR left parenthesis OR identifier; got end of "
-            "input"),
+            (
+                "at column 7: expected not OR left parenthesis OR identifier; got end of "
+                "input"
+            ),
         ),
         (
             "foo or or",


### PR DESCRIPTION
## Summary

- catch `BaseException` at the user-task execution boundary
- retain the dedicated `KeyboardInterrupt` branch and existing pytask control-flow handling
- turn raw `SystemExit`, including `SystemExit(0)`, into an ordinary failed task report
- verify unrelated execution, descendant skipping, and unconfiguration

## Root cause

The task protocol caught `Exception`, but `SystemExit` inherits directly from `BaseException`. A task calling `sys.exit(0)` therefore escaped report creation and cleanup and could terminate pytask with a successful process status.

## Impact

Raw `SystemExit` from task code now follows normal task failure semantics. Its exit code remains available on the reported exception, unrelated tasks continue, descendants skip, and the build returns pytask's failed-build exit code.

## Validation

- `uv run --group test pytest --snapshot-warn-unused`: 935 passed, 39 skipped, 4 xfailed
- `uv run --group test pytest tests/test_execute.py -q`: 57 passed, 1 xfailed
- `uv run --group typing --group test --isolated ty check --python-platform linux`: passed
- project-locked `uv run ruff check .`: passed
- project-locked `ruff format --check` for changed files: passed
- all non-Ruff pre-commit hooks: passed

The repository's `just` recipes cannot locate their configured shell on this Windows checkout. The pre-commit Ruff 0.16 hook also reports new baseline rules across untouched `main`, while the project lock provides Ruff 0.15.16. This PR was checked with the project-locked Ruff version and does not alter lint configuration.
