### PR TITLE
fix(import): detect task module path mismatches

### DIFF
--- a/src/_pytask/exceptions.py
+++ b/src/_pytask/exceptions.py
@@ -33,3 +33,7 @@ class ResolvingDependenciesError(PytaskError):
 
 class ExecutionError(PytaskError):
     """Exception during execution."""
+
+
+class ImportPathMismatchError(ImportError):
+    """Exception for a cached module imported from a different path."""

--- a/src/_pytask/path.py
+++ b/src/_pytask/path.py
@@ -17,6 +17,7 @@ from upath import UPath
 
 from _pytask._hashlib import file_digest
 from _pytask.cache import Cache
+from _pytask.exceptions import ImportPathMismatchError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from _pytask.typing import NodePath
 
 __all__ = [
+    "ImportPathMismatchError",
     "find_case_sensitive_path",
     "find_closest_ancestor",
     "find_common_ancestor",
@@ -182,21 +184,22 @@ def import_path(path: Path, root: Path) -> ModuleType:
     except CouldNotResolvePathError:
         pass
     else:
-        # If the given module name is already in sys.modules, do not import it again.
-        with contextlib.suppress(KeyError):
-            return sys.modules[module_name]
+        cached_module = _get_cached_module(module_name, path)
+        if cached_module is not None:
+            return cached_module
 
         mod = _import_module_using_spec(module_name, path, pkg_root)
         if mod is not None:
             return mod
 
     module_name = _module_name_from_path(path, root)
-    with contextlib.suppress(KeyError):
-        return sys.modules[module_name]
+    cached_module = _get_cached_module(module_name, path)
+    if cached_module is not None:
+        return cached_module
 
     spec = importlib.util.spec_from_file_location(module_name, str(path))
 
-    if spec is None:
+    if spec is None or spec.loader is None:
         msg = f"Can't find module {module_name!r} at location {path}."
         raise ImportError(msg)
 
@@ -205,6 +208,37 @@ def import_path(path: Path, root: Path) -> ModuleType:
     spec.loader.exec_module(mod)
     _insert_missing_modules(sys.modules, module_name)
     return mod
+
+
+def _get_cached_module(module_name: str, path: Path) -> ModuleType | None:
+    """Return a cached module only when it originates from the requested path."""
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is not None and _normalize_import_path(module_file) == (
+        _normalize_import_path(path)
+    ):
+        return module
+
+    imported_path = "<unknown>" if module_file is None else str(module_file)
+    msg = (
+        f"Module {module_name!r} was already imported from:\n{imported_path}\n\n"
+        f"Pytask is trying to collect:\n{path}\n\n"
+        "Pytask will not reuse a module from a different path.\n\n"
+        "Use a unique package or module name, or start the build in a fresh process "
+        "or notebook kernel."
+    )
+    raise ImportPathMismatchError(msg)
+
+
+def _normalize_import_path(path: str | os.PathLike[str]) -> str:
+    """Normalize a module path for cache comparisons."""
+    raw_path = os.fspath(path)
+    if raw_path.endswith((".pyc", ".pyo")):
+        raw_path = raw_path[:-1]
+    return os.path.normcase(str(Path(raw_path).resolve()))
 
 
 def _resolve_package_path(path: Path) -> Path | None:

--- a/src/pytask/__init__.py
+++ b/src/pytask/__init__.py
@@ -27,6 +27,7 @@ from _pytask.database_utils import create_database
 from _pytask.exceptions import CollectionError
 from _pytask.exceptions import ConfigurationError
 from _pytask.exceptions import ExecutionError
+from _pytask.exceptions import ImportPathMismatchError
 from _pytask.exceptions import NodeNotCollectedError
 from _pytask.exceptions import NodeLoadError
 from _pytask.exceptions import NodeNotFoundError
@@ -103,6 +104,7 @@ __all__ = [
     "ExecutionReport",
     "Exit",
     "ExitCode",
+    "ImportPathMismatchError",
     "Mark",
     "MarkDecorator",
     "MarkGenerator",

--- a/src/pytask/path.py
+++ b/src/pytask/path.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
+from _pytask.exceptions import ImportPathMismatchError
 from _pytask.path import hash_path
 from _pytask.path import import_path
 
-__all__ = ["hash_path", "import_path"]
+__all__ = ["ImportPathMismatchError", "hash_path", "import_path"]

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -14,6 +14,7 @@ from _pytask.collect import pytask_collect_node
 from _pytask.node_protocols import PPathNode
 from pytask import CollectionOutcome
 from pytask import ExitCode
+from pytask import ImportPathMismatchError
 from pytask import NodeInfo
 from pytask import PickleNode
 from pytask import Session
@@ -374,6 +375,42 @@ def test_collect_tasks_from_modules_with_the_same_name(tmp_path):
         assert node.function is not None  # type: ignore[union-attr]
         modules.add(node.function.__module__)  # type: ignore[union-attr]
     assert modules == {"a.task_module", "b.task_module"}
+
+
+def test_repeated_builds_report_import_path_mismatch(tmp_path):
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first_root.mkdir()
+    second_root.mkdir()
+    module_name = "task_repeated_build_import_path"
+    first_path = first_root / f"{module_name}.py"
+    second_path = second_root / f"{module_name}.py"
+    first_path.write_text(
+        "from pathlib import Path\n"
+        "def task_example():\n"
+        "    Path(__file__).with_name('result.txt').write_text('first')\n"
+    )
+    second_path.write_text(
+        "from pathlib import Path\n"
+        "def task_example():\n"
+        "    Path(__file__).with_name('result.txt').write_text('second')\n"
+    )
+
+    first_session = build(paths=first_root)
+    second_session = build(paths=second_root)
+
+    assert first_session.exit_code == ExitCode.OK
+    assert first_root.joinpath("result.txt").read_text() == "first"
+    assert second_session.exit_code == ExitCode.COLLECTION_FAILED
+    assert not second_root.joinpath("result.txt").exists()
+    failed_reports = [
+        report
+        for report in second_session.collection_reports
+        if report.outcome == CollectionOutcome.FAIL
+    ]
+    assert len(failed_reports) == 1
+    assert failed_reports[0].exc_info is not None
+    assert isinstance(failed_reports[0].exc_info[1], ImportPathMismatchError)
 
 
 def test_collect_module_name(tmp_path):

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -191,8 +191,10 @@ def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -
     [
         (
             "foo or",
-            ("at column 7: expected not OR left parenthesis OR identifier; got end of "
-            "input"),
+            (
+                "at column 7: expected not OR left parenthesis OR identifier; got end of "
+                "input"
+            ),
         ),
         (
             "foo or or",

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -24,6 +24,7 @@ from _pytask.path import is_non_local_path
 from _pytask.path import normalize_local_upath
 from _pytask.path import relative_to
 from _pytask.path import shorten_path
+from pytask.path import ImportPathMismatchError
 from pytask.path import import_path
 
 if TYPE_CHECKING:
@@ -191,6 +192,28 @@ def test_remembers_previous_imports(simple_module: Path, tmp_path: Path) -> None
     module1 = import_path(simple_module, root=tmp_path)
     module2 = import_path(simple_module, root=tmp_path)
     assert module1 is module2
+
+
+def test_rejects_cached_module_from_different_path(tmp_path: Path) -> None:
+    module_name = "task_import_path_mismatch"
+    first_path = tmp_path / "first" / f"{module_name}.py"
+    second_path = tmp_path / "second" / f"{module_name}.py"
+    first_path.parent.mkdir()
+    second_path.parent.mkdir()
+    first_path.write_text("VALUE = 'first'")
+    second_path.write_text("VALUE = 'second'")
+
+    first_module = import_path(first_path, root=first_path.parent)
+
+    assert first_module.VALUE == "first"
+    with pytest.raises(ImportPathMismatchError) as exc_info:
+        import_path(second_path, root=second_path.parent)
+
+    message = str(exc_info.value)
+    assert module_name in message
+    assert str(first_path) in message
+    assert str(second_path) in message
+    assert "fresh process or notebook kernel" in message
 
 
 def test_no_meta_path_found(


### PR DESCRIPTION
## Summary

- reuse a cached module only when its normalized source path matches the requested file
- raise and publicly expose `ImportPathMismatchError` for conflicting module names
- include the module name, both paths, and remediation guidance in the error
- cover direct imports, same-path cache reuse, and repeated programmatic builds

## Root cause

`import_path` returned `sys.modules[module_name]` without checking where that module was loaded from. Two builds in one process could therefore use the same task-module name from different project roots, causing the second build to execute the first project's code.

## Impact

Same-name/same-path imports retain their existing cache behavior. When the cached path differs, collection fails explicitly instead of executing stale code. Users are directed to use unique module/package names or restart the process or notebook kernel.

## Validation

- `uv run --group test pytest --snapshot-warn-unused`: 935 passed, 39 skipped, 4 xfailed
- `uv run --group test pytest tests/test_path.py tests/test_collect.py --snapshot-warn-unused -q`: 84 passed, 1 skipped
- `uv run --group typing --group test --isolated ty check --python-platform linux`: passed
- project-locked `uv run ruff check .`: passed
- project-locked `ruff format --check` for changed files: passed
- all non-Ruff pre-commit hooks: passed

The repository's `just` recipes cannot locate their configured shell on this Windows checkout. The pre-commit Ruff 0.16 hook also reports new baseline rules across untouched `main`, while the project lock provides Ruff 0.15.16. This PR was checked with the project-locked Ruff version and does not alter lint configuration.
