### PR TITLE
fix(execution): run sourceless tasks without paths

### DIFF
--- a/src/_pytask/execute.py
+++ b/src/_pytask/execute.py
@@ -174,7 +174,7 @@ def pytask_execute_task_setup(session: Session, task: PTask) -> None:  # noqa: C
         )
 
     if not needs_to_be_executed:
-        predecessors = set(dag.predecessors(task.signature)) | {task.signature}
+        predecessors = set(dag.predecessors(task.signature))
         for node_signature in node_and_neighbors(dag, task.signature):
             node = dag.nodes[node_signature]
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -965,6 +965,36 @@ def test_use_functional_interface_with_task(tmp_path):
     assert session.exit_code == ExitCode.OK
 
 
+def test_sourceless_task_without_path_always_executes(tmp_path):
+    namespace = {}
+    exec(  # noqa: S102
+        textwrap.dedent(
+            """
+            def function(path):
+                count = int(path.read_text()) if path.exists() else 0
+                path.write_text(str(count + 1))
+            """
+        ),
+        namespace,
+    )
+    task = TaskWithoutPath(
+        name="sourceless",
+        function=namespace["function"],
+        produces={"path": PathNode(path=tmp_path / "count.txt")},
+    )
+
+    assert task.state() is None
+
+    first_session = build(tasks=task, paths=tmp_path)
+    second_session = build(tasks=task, paths=tmp_path)
+
+    assert first_session.exit_code == ExitCode.OK
+    assert second_session.exit_code == ExitCode.OK
+    assert tmp_path.joinpath("count.txt").read_text() == "2"
+    assert first_session.execution_reports[0].outcome == TaskOutcome.SUCCESS
+    assert second_session.execution_reports[0].outcome == TaskOutcome.SUCCESS
+
+
 def test_collect_task(runner, tmp_path):
     source = """
     from pytask import Task, PathNode

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -191,8 +191,10 @@ def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -
     [
         (
             "foo or",
-            ("at column 7: expected not OR left parenthesis OR identifier; got end of "
-            "input"),
+            (
+                "at column 7: expected not OR left parenthesis OR identifier; got end of "
+                "input"
+            ),
         ),
         (
             "foo or or",


### PR DESCRIPTION
## Summary

- distinguish actual dependency predecessors from the task's own source state
- treat an unavailable task source state as changed instead of missing
- rerun source-less `TaskWithoutPath` tasks on every build
- retain missing-state errors for genuine dependencies

## Root cause

Execution setup added the task's own signature to the set of dependency predecessors. When `TaskWithoutPath.state()` returned `None` because `inspect.getsource()` was unavailable, pytask therefore reported the task itself as a missing required dependency.

## Impact

REPL-, notebook-, and dynamically created tasks without inspectable source now execute normally. Because their source cannot be compared safely, they are conservatively treated as changed and execute again on subsequent builds.

## Validation

- `uv run --group test pytest --snapshot-warn-unused`: 934 passed, 39 skipped, 4 xfailed
- `uv run --group test pytest tests/test_execute.py -q`: 56 passed, 1 xfailed
- `uv run --group typing --group test --isolated ty check --python-platform linux`: passed
- project-locked `uv run ruff check .`: passed
- project-locked `ruff format --check` for changed files: passed
- all non-Ruff pre-commit hooks: passed

The repository's `just` recipes cannot locate their configured shell on this Windows checkout. The pre-commit Ruff 0.16 hook also reports new baseline rules across untouched `main`, while the project lock provides Ruff 0.15.16. This PR was checked with the project-locked Ruff version and does not alter lint configuration.
