### PR TITLE
chore(lint): ignore Ruff copyright-header rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ select = ["ALL"]
 ignore = [
     "ANN401", # flake8-annotate typing.Any
     "COM812", # Comply with ruff-format.
+    "CPY001", # Missing copyright notice at top of file.
     "ISC001", # Comply with ruff-format.
     "FBT",
     "S101",   # raise errors for asserts.

--- a/src/_pytask/collect_utils.py
+++ b/src/_pytask/collect_utils.py
@@ -246,7 +246,7 @@ def parse_products_from_task_function(
     return out
 
 
-def _collect_nodes_and_provisional_nodes(  # noqa: PLR0913
+def _collect_nodes_and_provisional_nodes(  # noqa: PLR0913, PLR0917
     collection_func: Callable[..., Any],
     session: Session,
     node_path: Path,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,7 +70,7 @@ from pytask import import_optional_dependency
         ),
     ],
 )
-def test_check_for_optional_program(  # noqa: PLR0913
+def test_check_for_optional_program(  # noqa: PLR0913, PLR0917
     name, extra, errors, caller, expectation, expected
 ):
     with expectation:

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -191,8 +191,10 @@ def test_keyword_option_parametrize(tmp_path, expr: str, expected_passed: str) -
     [
         (
             "foo or",
-            ("at column 7: expected not OR left parenthesis OR identifier; got end of "
-            "input"),
+            (
+                "at column 7: expected not OR left parenthesis OR "
+                "identifier; got end of input"
+            ),
         ),
         (
             "foo or or",


### PR DESCRIPTION
## Summary

- ignore Ruff's `CPY001` copyright-header rule globally
- extend two existing high-argument-count suppressions to Ruff 0.16's `PLR0917`
- apply Ruff 0.16-compatible formatting to the existing marker-expression test

## Root cause

The pre-commit configuration uses Ruff 0.16 with `select = ["ALL"]`. Ruff 0.16
reports `CPY001` for hundreds of existing files even though the repository does not
enforce copyright headers. After ignoring that rule, Ruff 0.16 also exposes two
intentional APIs under its newer positional-argument rule.

## Impact

This restores a clean Ruff 0.16 pre-commit run without adding copyright boilerplate
throughout the repository or changing runtime behavior.

## Validation

- `uvx prek run -a`: passed
- `uv run --group typing --group test --isolated ty check --python-platform linux`: passed
- `uv run --group test pytest --snapshot-warn-unused`: 933 passed, 39 skipped, 4 xfailed
