### PR TITLE
docs: reference pytest-derived modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- Documents the pytest provenance of the adapted debugging, marker, and warning
+  modules.
 - [#889](https://github.com/pytask-dev/pytask/pull/889) improves typing for tree
   operations by wrapping optree's pytree utilities with pytask-specific signatures
   and requiring optree 0.16.0 or newer.

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -1,4 +1,8 @@
-"""Contains everything related to debugging."""
+"""Contains everything related to debugging.
+
+The PDB integration is adapted from pytest's ``_pytest.debugging`` module:
+https://github.com/pytest-dev/pytest/blob/main/src/_pytest/debugging.py
+"""
 
 from __future__ import annotations
 

--- a/src/_pytask/mark/expression.py
+++ b/src/_pytask/mark/expression.py
@@ -20,6 +20,9 @@ The semantics are:
 - ident evaluates to True of False according to a provided matcher function.
 - or/and/not evaluate according to the usual boolean semantics.
 
+This module is adapted from pytest's ``_pytest.mark.expression`` module:
+https://github.com/pytest-dev/pytest/blob/main/src/_pytest/mark/expression.py
+
 """
 
 from __future__ import annotations

--- a/src/_pytask/mark/structures.py
+++ b/src/_pytask/mark/structures.py
@@ -1,3 +1,10 @@
+"""Contains the data structures for marks.
+
+The mark decorator and generator implementation originated in pytest's
+``_pytest.mark.structures`` module and has been adapted to pytask's task model:
+https://github.com/pytest-dev/pytest/blob/main/src/_pytest/mark/structures.py
+"""
+
 from __future__ import annotations
 
 import warnings

--- a/src/_pytask/warnings.py
+++ b/src/_pytask/warnings.py
@@ -1,4 +1,8 @@
-"""Contains code for capturing warnings."""
+"""Contains code for capturing warnings.
+
+The warning-capture plugin is adapted from pytest's ``_pytest.warnings`` module:
+https://github.com/pytest-dev/pytest/blob/main/src/_pytest/warnings.py
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Add pytest provenance references to the adapted debugging, marker, and warning modules, and document the change in the Unreleased changelog. Documentation-only; git diff --check passed and lint hooks passed apart from the intentional no-commit-to-main hook.