### PR TITLE
fix: avoid replaying tee capture output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- Prevents tee-sys capture from replaying output that was already displayed when
+  capture stops before its buffer is read.
 - [#968](https://github.com/pytask-dev/pytask/pull/968) improves the performance of file
   descriptor capture for tasks that produce no output.
 - Documents the pytest provenance of the adapted debugging, marker, and warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
-- Prevents tee-sys capture from replaying output that was already displayed when
-  capture stops before its buffer is read.
+- [#970](https://github.com/pytask-dev/pytask/pull/970) prevents tee-sys capture from
+  replaying output that was already displayed when capture stops before its buffer is
+  read.
 - [#968](https://github.com/pytask-dev/pytask/pull/968) improves the performance of file
   descriptor capture for tasks that produce no output.
 - Documents the pytest provenance of the adapted debugging, marker, and warning

--- a/src/_pytask/capture.py
+++ b/src/_pytask/capture.py
@@ -769,7 +769,11 @@ class CaptureManager:
 
     def stop_capturing(self) -> None:
         if self._capturing is not None:
-            self._capturing.pop_outerr_to_orig()
+            if self._method == CaptureMethod.TEE_SYS:
+                # TeeCaptureIO already forwarded the output to the original streams.
+                self._capturing.readouterr()
+            else:
+                self._capturing.pop_outerr_to_orig()
             self._capturing.stop_capturing()
             self._capturing = None
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -187,6 +187,28 @@ def TeeStdCapture(  # noqa: N802
 
 
 class TestCaptureManager:
+    def test_stop_capturing_does_not_replay_tee_output(self, capsys):
+        capman = CaptureManager(CaptureMethod.TEE_SYS)
+        capman.start_capturing()
+        print("stdout")
+        print("stderr", file=sys.stderr)
+
+        capman.stop_capturing()
+
+        captured = capsys.readouterr()
+        assert captured == ("stdout\n", "stderr\n")
+
+    def test_stop_capturing_replays_non_tee_output(self, capsys):
+        capman = CaptureManager(CaptureMethod.SYS)
+        capman.start_capturing()
+        print("stdout")
+        print("stderr", file=sys.stderr)
+
+        capman.stop_capturing()
+
+        captured = capsys.readouterr()
+        assert captured == ("stdout\n", "stderr\n")
+
     @pytest.mark.parametrize(
         "method", [CaptureMethod.NO, CaptureMethod.SYS, CaptureMethod.FD]
     )


### PR DESCRIPTION
Drain tee capture buffers without writing them back when capture stops, because TeeCaptureIO already forwards output live. Preserve buffered-output replay for non-tee capture modes. Adds regression coverage for both behaviors and a changelog entry. Adapted from pytest-dev/pytest@46ea2a3. Validation: the full capture test module and just lint pass.