### PR TITLE
fix: preserve help for wrapped pdb commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
-- Restores help text for PDB commands wrapped by pytask.
+- [#971](https://github.com/pytask-dev/pytask/pull/971) restores help text for
+  PDB commands wrapped by pytask.
 - [#968](https://github.com/pytask-dev/pytask/pull/968) improves the performance of file
   descriptor capture for tasks that produce no output.
 - Documents the pytest provenance of the adapted debugging, marker, and warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- Restores help text for PDB commands wrapped by pytask.
 - [#968](https://github.com/pytask-dev/pytask/pull/968) improves the performance of file
   descriptor capture for tasks that produce no output.
 - Documents the pytest provenance of the adapted debugging, marker, and warning

--- a/src/_pytask/debugging.py
+++ b/src/_pytask/debugging.py
@@ -213,6 +213,9 @@ class PytaskPDB:
                 cls._recursive_debug -= 1
                 return ret
 
+            if hasattr(pdb_cls, "do_debug"):
+                do_debug.__doc__ = pdb_cls.do_debug.__doc__
+
             def do_continue(self, arg: Any) -> int:
                 ret = super().do_continue(arg)
                 if cls._recursive_debug == 0:
@@ -239,16 +242,17 @@ class PytaskPDB:
                 self._continued = True
                 return ret
 
+            if hasattr(pdb_cls, "do_continue"):
+                do_continue.__doc__ = pdb_cls.do_continue.__doc__
+
             do_c = do_cont = do_continue
 
             def do_quit(self, arg: Any) -> int:
-                """Raise Exit outcome when quit command is used in pdb.
-
-                This is a bit of a hack - it would be better if BdbQuit could be
-                handled, but this would require to wrap the whole pytest run, and adjust
-                the report etc.
-
-                """
+                # Raise Exit outcome when quit command is used in pdb.
+                #
+                # This is a bit of a hack - it would be better if BdbQuit could be
+                # handled, but this would require to wrap the whole pytest run, and
+                # adjust the report etc.
                 ret = super().do_quit(arg)
 
                 if cls._recursive_debug == 0:
@@ -256,6 +260,9 @@ class PytaskPDB:
                     raise Exit(msg)
 
                 return ret
+
+            if hasattr(pdb_cls, "do_quit"):
+                do_quit.__doc__ = pdb_cls.do_quit.__doc__
 
             do_q = do_quit
             do_exit = do_quit

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import pdb  # noqa: T100
 import re
 import sys
 import textwrap
@@ -9,6 +10,7 @@ from contextlib import ExitStack as does_not_raise  # noqa: N813
 import click
 import pytest
 
+from _pytask.debugging import PytaskPDB
 from _pytask.debugging import _pdbcls_callback
 from pytask import ExitCode
 from pytask import cli
@@ -42,6 +44,24 @@ def test_capture_callback(value, expected, expectation):
     with expectation:
         result = _pdbcls_callback(None, None, value)  # type: ignore[arg-type]
         assert result == expected
+
+
+def test_pdb_wrapped_commands_keep_docstrings():
+    class CustomPdb(pdb.Pdb):
+        def do_debug(self, arg):
+            """Custom help for debug."""
+
+        def do_continue(self, arg):
+            """Custom help for continue."""
+
+        def do_quit(self, arg):
+            """Custom help for quit."""
+
+    wrapped = PytaskPDB._get_pdb_wrapper_class(CustomPdb, None, None)  # type: ignore[arg-type]
+
+    assert wrapped.do_debug.__doc__ == CustomPdb.do_debug.__doc__
+    assert wrapped.do_continue.__doc__ == CustomPdb.do_continue.__doc__
+    assert wrapped.do_quit.__doc__ == CustomPdb.do_quit.__doc__
 
 
 def _flush(child):


### PR DESCRIPTION
## Summary

- copy `do_debug`, `do_continue`, and `do_quit` docstrings from the underlying PDB class to pytask's wrappers
- preserve command help supplied by custom `--pdbcls` implementations
- add a cross-platform regression test and changelog entry

Adapted from pytest commit pytest-dev/pytest@064638352d2c1f794fb494e52c0be522a6cb58c4.

## Validation

- `uv run --group test pytest tests/test_debugging.py`
- `just typing`
- `just lint`