### PR TITLE
fix: apply warning filters during configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- Configured warning filters now apply to warnings emitted by configuration hooks.
 - [#973](https://github.com/pytask-dev/pytask/pull/973) enables navigating chained
   exceptions in post-mortem PDB sessions on Python 3.13 and newer.
 - [#969](https://github.com/pytask-dev/pytask/pull/969) initializes readline before

--- a/src/_pytask/config.py
+++ b/src/_pytask/config.py
@@ -12,6 +12,7 @@ from _pytask.pluginmanager import hookimpl
 from _pytask.shared import parse_markers
 from _pytask.shared import parse_paths
 from _pytask.shared import to_list
+from _pytask.warnings_utils import catch_configured_warnings
 
 if TYPE_CHECKING:
     from pluggy import PluginManager
@@ -73,8 +74,13 @@ def pytask_configure(pm: PluginManager, raw_config: dict[str, Any]) -> dict[str,
     config = {"pm": pm, "markers": {}} | raw_config
     config["markers"] = parse_markers(markers)
 
-    pm.hook.pytask_parse_config(config=config)
-    pm.hook.pytask_post_parse(config=config)
+    with catch_configured_warnings(config, record=False):
+        pm.hook.pytask_parse_config(config=config)
+
+    # Start a new context so filters normalized during parsing apply to post-parse
+    # hooks.
+    with catch_configured_warnings(config, record=False):
+        pm.hook.pytask_post_parse(config=config)
 
     return config
 

--- a/src/_pytask/warnings_utils.py
+++ b/src/_pytask/warnings_utils.py
@@ -9,6 +9,7 @@ import textwrap
 import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import NamedTuple
 from typing import cast
 
@@ -17,6 +18,7 @@ from _pytask.outcomes import Exit
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from collections.abc import Mapping
 
     from _pytask.node_protocols import PTask
     from _pytask.session import Session
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "WarningReport",
+    "catch_configured_warnings",
     "catch_warnings_for_item",
     "parse_filterwarnings",
     "parse_warning_filter",
@@ -155,6 +158,18 @@ def parse_filterwarnings(x: str | list[str] | None) -> list[str]:
 
 
 @contextmanager
+def catch_configured_warnings(
+    config: Mapping[str, Any], *, record: bool
+) -> Generator[list[warnings.WarningMessage] | None, None, None]:
+    """Apply configured warning filters in a warnings-catching context."""
+    with warnings.catch_warnings(record=record) as log:
+        for arg in parse_filterwarnings(config.get("filterwarnings")):
+            warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
+
+        yield log
+
+
+@contextmanager
 def catch_warnings_for_item(
     session: Session,
     task: PTask | None = None,
@@ -165,12 +180,8 @@ def catch_warnings_for_item(
     ``item`` can be None if we are not in the context of an item execution.
 
     """
-    with warnings.catch_warnings(record=True) as log:
-        # mypy can't infer that record=True means log is not None; help it.
+    with catch_configured_warnings(session.config, record=True) as log:
         assert log is not None
-
-        for arg in session.config["filterwarnings"]:
-            warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
 
         # apply filters from "filterwarnings" marks
         if task is not None:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,16 +1,35 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import textwrap
+import warnings
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
+from _pytask.pluginmanager import hookimpl
 from _pytask.warnings_utils import _resolve_warning_category
 from pytask import ExitCode
 from pytask import build
 from pytask import cli
 from tests.conftest import run_in_subprocess
+
+
+def _register_plugin_for_build(monkeypatch: pytest.MonkeyPatch, plugin: object) -> None:
+    """Add a plugin to the fresh plugin manager created by ``build``."""
+    build_module = importlib.import_module("_pytask.build")
+    get_plugin_manager = build_module.get_plugin_manager
+
+    def get_plugin_manager_with_plugin():
+        plugin_manager = get_plugin_manager()
+        plugin_manager.register(plugin)
+        return plugin_manager
+
+    monkeypatch.setattr(
+        build_module, "get_plugin_manager", get_plugin_manager_with_plugin
+    )
 
 
 def test_resolve_warning_category_uses_import_module(monkeypatch):
@@ -236,3 +255,52 @@ def test_wrong_value_in_config_in_filterwarnings(tmp_path, runner):
     result = runner.invoke(cli, [tmp_path.as_posix()])
     assert result.exit_code == ExitCode.CONFIGURATION_FAILED
     assert "'filterwarnings' must be a str, list[str] or None." in result.output
+
+
+@pytest.mark.parametrize("hook_name", ["pytask_parse_config", "pytask_post_parse"])
+@pytest.mark.parametrize("tryfirst", [True, False])
+def test_filterwarnings_apply_to_configuration_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    hook_name: str,
+    tryfirst: bool,
+) -> None:
+    """Configured filters apply to early and regular configuration hooks."""
+
+    def emit_warning(config: dict[str, Any]) -> None:  # noqa: ARG001
+        warnings.warn("from configuration hook", UserWarning, stacklevel=1)
+
+    plugin = SimpleNamespace()
+    setattr(plugin, hook_name, hookimpl(tryfirst=tryfirst)(emit_warning))
+    _register_plugin_for_build(monkeypatch, plugin)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        session = build(
+            paths=tmp_path,
+            filterwarnings=["ignore::UserWarning"],
+        )
+
+    assert session.exit_code == ExitCode.OK
+    assert not any(
+        str(record.message) == "from configuration hook" for record in records
+    )
+
+
+def test_error_filter_applies_to_configuration_hooks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An error filter turns configuration warnings into configuration failures."""
+
+    def emit_warning(config: dict[str, Any]) -> None:  # noqa: ARG001
+        warnings.warn("from configuration hook", UserWarning, stacklevel=1)
+
+    plugin = SimpleNamespace(pytask_post_parse=hookimpl(emit_warning))
+    _register_plugin_for_build(monkeypatch, plugin)
+
+    session = build(
+        paths=tmp_path,
+        filterwarnings=["error::UserWarning"],
+    )
+
+    assert session.exit_code == ExitCode.CONFIGURATION_FAILED


### PR DESCRIPTION
## Summary

- apply configured warning filters while `pytask_parse_config` and `pytask_post_parse` hooks run
- centralize configured warning handling for reuse during collection and task execution
- cover ignored warnings, warnings promoted to errors, and early/regular configuration hooks

Adapted from pytest-dev/pytest#14760.

## Tests

- `uv run --group test pytest tests/test_config.py tests/test_warnings.py -q`
- `just typing`
- `uv run pre-commit run --files src/_pytask/config.py src/_pytask/warnings_utils.py tests/test_warnings.py CHANGELOG.md`
