### PR TITLE
fix: validate strict marker expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- Marker names in `-m` expressions are validated when `--strict-markers` is enabled.
 - Configured warning filters now apply to warnings emitted by configuration hooks.
 - [#973](https://github.com/pytask-dev/pytask/pull/973) enables navigating chained
   exceptions in post-mortem PDB sessions on Python 3.13 and newer.

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -227,6 +227,16 @@ def select_by_mark(session: Session, dag: DAG) -> set[str] | None:
         msg = f"Wrong expression passed to '-m': {matchexpr}: {e}"
         raise ValueError(msg) from None
 
+    if session.config["strict_markers"]:
+        unknown_markers = expression.idents() - session.config["markers"].keys()
+        if unknown_markers:
+            unknown = ", ".join(sorted(unknown_markers))
+            msg = (
+                f"Unknown marker(s) in '-m' expression: {unknown}. "
+                "Use 'pytask markers' to see available markers."
+            )
+            raise ValueError(msg)
+
     remaining: set[str] = set()
     for task in session.tasks:
         if expression.evaluate(MarkMatcher.from_task(task)):

--- a/src/_pytask/mark/expression.py
+++ b/src/_pytask/mark/expression.py
@@ -83,9 +83,10 @@ class ParseError(Exception):
 
 
 class Scanner:
-    __slots__ = ("current", "tokens")
+    __slots__ = ("current", "idents", "tokens")
 
     def __init__(self, input_: str) -> None:
+        self.idents: set[str] = set()
         self.tokens = self.lex(input_)
         self.current = next(self.tokens)
 
@@ -146,13 +147,13 @@ class Scanner:
 IDENT_PREFIX = "$"
 
 
-def expression(s: Scanner) -> ast.Expression:
+def expression(s: Scanner) -> tuple[ast.Expression, frozenset[str]]:
     if s.accept(TokenType.EOF):
         ret: ast.expr = ast.Constant(False)
     else:
         ret = expr(s)
         s.accept(TokenType.EOF, reject=True)
-    return ast.fix_missing_locations(ast.Expression(ret))
+    return ast.fix_missing_locations(ast.Expression(ret)), frozenset(s.idents)
 
 
 def expr(s: Scanner) -> ast.expr:
@@ -180,6 +181,7 @@ def not_expr(s: Scanner) -> ast.expr:
         return ret
     ident = s.accept(TokenType.IDENT)
     if ident:
+        s.idents.add(ident.value)
         return ast.Name(IDENT_PREFIX + ident.value, ast.Load())
     s.reject((TokenType.NOT, TokenType.LPAREN, TokenType.IDENT))
     return None  # ty: ignore[invalid-return-type]  # Unreachable: reject() raises
@@ -208,10 +210,11 @@ class Expression:
 
     """
 
-    __slots__ = ("code",)
+    __slots__ = ("_idents", "code")
 
-    def __init__(self, code: types.CodeType) -> None:
+    def __init__(self, code: types.CodeType, idents: frozenset[str]) -> None:
         self.code = code
+        self._idents = idents
 
     @classmethod
     def compile_(cls, input_: str) -> Expression:
@@ -223,13 +226,17 @@ class Expression:
             The input expression - one line.
 
         """
-        astexpr = expression(Scanner(input_))
+        astexpr, idents = expression(Scanner(input_))
         code: types.CodeType = compile(
             astexpr,
             filename="<pytask match expression>",
             mode="eval",
         )
-        return cls(code)
+        return cls(code, idents)
+
+    def idents(self) -> frozenset[str]:
+        """Return all identifiers which appear in the expression."""
+        return self._idents
 
     def evaluate(self, matcher: Callable[[str], bool]) -> bool:
         """Evaluate the match expression.

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -357,6 +357,45 @@ def test_error_with_unknown_marker_and_strict(runner, tmp_path):
     assert "Unknown pytask.mark.unknown" in result.output
 
 
+@pytest.mark.parametrize(
+    ("marker_expression", "strict_markers", "expected_exit_code"),
+    [
+        ("registered", True, ExitCode.OK),
+        ("unknown", False, ExitCode.OK),
+        ("unknown", True, ExitCode.DAG_FAILED),
+    ],
+)
+def test_strict_markers_validate_marker_expression(
+    runner,
+    tmp_path,
+    marker_expression: str,
+    strict_markers: bool,
+    expected_exit_code: ExitCode,
+) -> None:
+    tmp_path.joinpath("pyproject.toml").write_text(
+        "[tool.pytask.ini_options]\nmarkers = {'registered' = 'A registered marker.'}"
+    )
+    tmp_path.joinpath("task_module.py").write_text(
+        textwrap.dedent(
+            """
+            import pytask
+
+            @pytask.mark.registered
+            def task_example(): ...
+            """
+        )
+    )
+    args = [tmp_path.as_posix(), "-m", marker_expression]
+    if strict_markers:
+        args.append("--strict-markers")
+
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == expected_exit_code
+    if strict_markers and marker_expression == "unknown":
+        assert "Unknown marker(s) in '-m' expression: unknown" in result.output
+
+
 @pytest.mark.filterwarnings("ignore:Unknown pytask\\.mark\\.foo")
 def test_strict_markers_do_not_leak_after_unconfigure(runner, tmp_path):
     source = """

--- a/tests/test_mark_expression.py
+++ b/tests/test_mark_expression.py
@@ -25,6 +25,18 @@ def test_empty_is_false() -> None:
 @pytest.mark.parametrize(
     ("expr", "expected"),
     [
+        ("", frozenset()),
+        ("first", frozenset({"first"})),
+        ("first and (second or first)", frozenset({"first", "second"})),
+    ],
+)
+def test_expression_exposes_identifiers(expr: str, expected: frozenset[str]) -> None:
+    assert Expression.compile_(expr).idents() == expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
         ("true", True),
         ("false", False),
         ("not true", False),


### PR DESCRIPTION
## Summary

- collect identifiers while compiling `-m` expressions
- reject unregistered marker names when `--strict-markers` is enabled
- preserve current behavior when strict marker checking is disabled

Adapted from pytest-dev/pytest#2781.

## Tests

- `uv run --group test pytest tests/test_mark.py tests/test_mark_expression.py -q`
- `just typing`
- targeted pre-commit checks

## Merge note

This PR and the SyntaxError expression-parser PR are independent but both touch `src/_pytask/mark/expression.py`; whichever merges second may need a small rebase.
