### PR TITLE
refactor: use SyntaxError for mark expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
-- Marker names in `-m` expressions are validated when `--strict-markers` is enabled.
-- Configured warning filters now apply to warnings emitted by configuration hooks.
+- [#976](https://github.com/pytask-dev/pytask/pull/976) makes invalid marker and
+  keyword expressions raise the standard `SyntaxError` instead of a custom parser
+  exception.
+- [#975](https://github.com/pytask-dev/pytask/pull/975) validates marker names in `-m`
+  expressions when `--strict-markers` is enabled.
+- [#974](https://github.com/pytask-dev/pytask/pull/974) applies configured warning
+  filters to warnings emitted by configuration hooks.
 - [#973](https://github.com/pytask-dev/pytask/pull/973) enables navigating chained
   exceptions in post-mortem PDB sessions on Python 3.13 and newer.
 - [#969](https://github.com/pytask-dev/pytask/pull/969) initializes readline before
@@ -23,8 +28,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
   categories.
 - [#968](https://github.com/pytask-dev/pytask/pull/968) improves the performance of file
   descriptor capture for tasks that produce no output.
-- Documents the pytest provenance of the adapted debugging, marker, and warning
-  modules.
+- [#967](https://github.com/pytask-dev/pytask/pull/967) documents the pytest provenance
+  of the adapted debugging, marker, and warning modules.
 - [#889](https://github.com/pytask-dev/pytask/pull/889) improves typing for tree
   operations by wrapping optree's pytree utilities with pytask-specific signatures
   and requiring optree 0.16.0 or newer.

--- a/src/_pytask/lock.py
+++ b/src/_pytask/lock.py
@@ -27,7 +27,6 @@ from _pytask.lockfile import build_portable_task_id
 from _pytask.mark import Expression
 from _pytask.mark import KeywordMatcher
 from _pytask.mark import MarkMatcher
-from _pytask.mark import ParseError
 from _pytask.node_protocols import PNode
 from _pytask.node_protocols import PProvisionalNode
 from _pytask.node_protocols import PTask
@@ -75,8 +74,11 @@ def _expression_filter(
 ) -> set[str]:
     try:
         compiled = Expression.compile_(expression)
-    except ParseError as e:
-        msg = f"Wrong expression passed to {option!r}: {expression}: {e}"
+    except SyntaxError as e:
+        msg = (
+            f"Wrong expression passed to {option!r}: {e.text}: "
+            f"at column {e.offset}: {e.msg}"
+        )
         raise ValueError(msg) from None
 
     return {

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -16,7 +16,6 @@ from _pytask.console import console
 from _pytask.dag_utils import task_and_preceding_tasks
 from _pytask.exceptions import ConfigurationError
 from _pytask.mark.expression import Expression
-from _pytask.mark.expression import ParseError
 from _pytask.mark.structures import MARK_GEN
 from _pytask.mark.structures import Mark
 from _pytask.mark.structures import MarkDecorator
@@ -41,7 +40,6 @@ __all__ = [
     "Mark",
     "MarkDecorator",
     "MarkGenerator",
-    "ParseError",
     "select_by_after_keyword",
     "select_by_keyword",
     "select_by_mark",
@@ -168,8 +166,10 @@ def select_by_keyword(session: Session, dag: DAG) -> set[str] | None:
 
     try:
         expression = Expression.compile_(keywordexpr)
-    except ParseError as e:
-        msg = f"Wrong expression passed to '-k': {keywordexpr}: {e}"
+    except SyntaxError as e:
+        msg = (
+            f"Wrong expression passed to '-k': {e.text}: at column {e.offset}: {e.msg}"
+        )
         raise ValueError(msg) from None
 
     remaining: set[str] = set()
@@ -184,8 +184,11 @@ def select_by_after_keyword(session: Session, after: str) -> set[str]:
     """Select tasks defined by the after keyword."""
     try:
         expression = Expression.compile_(after)
-    except ParseError as e:
-        msg = f"Wrong expression passed to 'after': {after}: {e}"
+    except SyntaxError as e:
+        msg = (
+            f"Wrong expression passed to 'after': {e.text}: "
+            f"at column {e.offset}: {e.msg}"
+        )
         raise ValueError(msg) from None
 
     ancestors: set[str] = set()
@@ -223,8 +226,10 @@ def select_by_mark(session: Session, dag: DAG) -> set[str] | None:
 
     try:
         expression = Expression.compile_(matchexpr)
-    except ParseError as e:
-        msg = f"Wrong expression passed to '-m': {matchexpr}: {e}"
+    except SyntaxError as e:
+        msg = (
+            f"Wrong expression passed to '-m': {e.text}: at column {e.offset}: {e.msg}"
+        )
         raise ValueError(msg) from None
 
     if session.config["strict_markers"]:

--- a/src/_pytask/mark/expression.py
+++ b/src/_pytask/mark/expression.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
     from typing import NoReturn
 
 
-__all__ = ["Expression", "ParseError"]
+__all__ = ["Expression"]
+
+
+FILE_NAME = "<pytask match expression>"
 
 
 class TokenType(enum.Enum):
@@ -62,31 +65,12 @@ class Token:
     pos: int
 
 
-class ParseError(Exception):
-    """The expression contains invalid syntax.
-
-    Attributes
-    ----------
-    column : int
-        The column in the line where the error occurred (1-based).
-    message : str
-        A description of the error.
-
-    """
-
-    def __init__(self, column: int, message: str) -> None:
-        self.column = column
-        self.message = message
-
-    def __str__(self) -> str:
-        return f"at column {self.column}: {self.message}"
-
-
 class Scanner:
-    __slots__ = ("current", "idents", "tokens")
+    __slots__ = ("current", "idents", "input", "tokens")
 
     def __init__(self, input_: str) -> None:
         self.idents: set[str] = set()
+        self.input = input_
         self.tokens = self.lex(input_)
         self.current = next(self.tokens)
 
@@ -115,9 +99,10 @@ class Scanner:
                         yield Token(TokenType.IDENT, value, pos)
                     pos += len(value)
                 else:
-                    raise ParseError(
-                        pos + 1,
-                        f'unexpected character "{input_[pos]}"',
+                    msg = f'unexpected character "{input_[pos]}"'
+                    raise SyntaxError(
+                        msg,
+                        (FILE_NAME, 1, pos + 1, input_),
                     )
         yield Token(TokenType.EOF, "", pos)
 
@@ -132,12 +117,13 @@ class Scanner:
         return None
 
     def reject(self, expected: Sequence[TokenType]) -> NoReturn:
-        raise ParseError(
-            self.current.pos + 1,
-            "expected {}; got {}".format(
-                " OR ".join(type_.value for type_ in expected),
-                self.current.type_.value,
-            ),
+        msg = "expected {}; got {}".format(
+            " OR ".join(type_.value for type_ in expected),
+            self.current.type_.value,
+        )
+        raise SyntaxError(
+            msg,
+            (FILE_NAME, 1, self.current.pos + 1, self.input),
         )
 
 

--- a/tests/test_mark_expression.py
+++ b/tests/test_mark_expression.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from _pytask.mark.expression import Expression
-from _pytask.mark.expression import ParseError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -132,10 +131,11 @@ def test_syntax_oddeties(expr: str, expected: bool) -> None:
     ],
 )
 def test_syntax_errors(expr: str, column: int, message: str) -> None:
-    with pytest.raises(ParseError) as excinfo:
+    with pytest.raises(SyntaxError) as excinfo:
         evaluate(expr, lambda ident: True)  # noqa: ARG005
-    assert excinfo.value.column == column
-    assert excinfo.value.message == message
+    assert excinfo.value.offset == column
+    assert excinfo.value.msg == message
+    assert excinfo.value.text == expr
 
 
 @pytest.mark.parametrize(
@@ -194,7 +194,7 @@ def test_valid_idents(ident: str) -> None:
     ],
 )
 def test_invalid_idents(ident: str) -> None:
-    with pytest.raises(ParseError):
+    with pytest.raises(SyntaxError):
         evaluate(ident, lambda ident: True)  # noqa: ARG005
 
 
@@ -211,5 +211,5 @@ def test_backslash_not_treated_specially() -> None:
 
     assert evaluate(r"\nfoo\n", matcher)
     assert not evaluate(r"foo", matcher)
-    with pytest.raises(ParseError):
+    with pytest.raises(SyntaxError):
         evaluate("\nfoo\n", matcher)


### PR DESCRIPTION
## Summary

- replace the custom mark-expression `ParseError` with standard `SyntaxError`
- retain source text, column offsets, and parser messages on syntax failures
- update task selection and lock command filtering to consume the standard exception

Adapted from pytest commit d77cbfac04a99cca1520a0d3e77d4dd71cb274e4.

## Tests

- `uv run --group test pytest tests/test_mark_expression.py tests/test_mark.py tests/test_lock_command.py tests/test_task.py -q`
- `just typing`
- targeted pre-commit checks

## Merge note

This PR and #975 are independent but both touch `src/_pytask/mark/expression.py`; whichever merges second may need a small rebase.
