### PR TITLE
feat: select tasks by marker metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ releases are available on [PyPI](https://pypi.org/project/pytask) and
 
 ## Unreleased
 
+- [#977](https://github.com/pytask-dev/pytask/pull/977) allows marker expressions
+  passed to `-m` to select tasks by marker keyword arguments.
 - [#976](https://github.com/pytask-dev/pytask/pull/976) makes invalid marker and
   keyword expressions raise the standard `SyntaxError` instead of a custom parser
   exception.

--- a/docs/source/tutorials/selecting_tasks.md
+++ b/docs/source/tutorials/selecting_tasks.md
@@ -31,6 +31,26 @@ analysis.
 $ pytask -m "(data_management and not plots) or (analysis and plots)"
 ```
 
+Markers can also store metadata in keyword arguments. For example, the following marker
+records the data and model used by a prediction task.
+
+```python
+@pytask.mark.prediction(data="customer_churn", model="random_forest")
+def task_create_predictions():
+    pass
+```
+
+Pass keyword arguments in a marker expression to select tasks by this metadata.
+
+```console
+$ pytask -m 'prediction(data="customer_churn", model="random_forest")'
+```
+
+A task matches if one marker with the requested name contains all keyword arguments in
+the expression. The marker can contain additional keyword arguments. Marker expressions
+support unescaped strings, positive and negative integers, `True`, `False`, and `None`.
+Keyword arguments are only supported in marker expressions passed to `-m`.
+
 If you create your markers, use the
 [`pytask markers`](../reference_guides/commands.md#pytask-markers) command to register
 and document them.

--- a/src/_pytask/lock.py
+++ b/src/_pytask/lock.py
@@ -80,6 +80,9 @@ def _expression_filter(
             f"at column {e.offset}: {e.msg}"
         )
         raise ValueError(msg) from None
+    if option == "-k" and compiled.has_keyword_arguments():
+        msg = "Keyword expressions do not support call parameters."
+        raise ValueError(msg)
 
     return {
         task.signature for task in tasks if compiled.evaluate(matcher_from_task(task))

--- a/src/_pytask/mark/__init__.py
+++ b/src/_pytask/mark/__init__.py
@@ -151,11 +151,11 @@ class KeywordMatcher:
 
         return cls(mapped_names)
 
-    def __call__(self, subname: str) -> bool:
+    def __call__(self, subname: str, /, **kwargs: str | int | bool | None) -> bool:
         subname = subname.lower()
         names = (name.lower() for name in self._names)
 
-        return any(subname in name for name in names)
+        return not kwargs and any(subname in name for name in names)
 
 
 def select_by_keyword(session: Session, dag: DAG) -> set[str] | None:
@@ -171,6 +171,9 @@ def select_by_keyword(session: Session, dag: DAG) -> set[str] | None:
             f"Wrong expression passed to '-k': {e.text}: at column {e.offset}: {e.msg}"
         )
         raise ValueError(msg) from None
+    if expression.has_keyword_arguments():
+        msg = "Keyword expressions do not support call parameters."
+        raise ValueError(msg)
 
     remaining: set[str] = set()
     for task in session.tasks:
@@ -190,6 +193,9 @@ def select_by_after_keyword(session: Session, after: str) -> set[str]:
             f"at column {e.offset}: {e.msg}"
         )
         raise ValueError(msg) from None
+    if expression.has_keyword_arguments():
+        msg = "Keyword expressions do not support call parameters."
+        raise ValueError(msg)
 
     ancestors: set[str] = set()
     for task in session.tasks:
@@ -197,6 +203,9 @@ def select_by_after_keyword(session: Session, after: str) -> set[str]:
             ancestors.add(task.signature)
 
     return ancestors
+
+
+_NOT_SET = object()
 
 
 @dataclass(slots=True)
@@ -207,15 +216,22 @@ class MarkMatcher:
 
     """
 
-    own_mark_names: set[str]
+    own_mark_name_mapping: dict[str, list[Mark]]
 
     @classmethod
     def from_task(cls, task: PTask) -> MarkMatcher:
-        mark_names = {mark.name for mark in task.markers}
-        return cls(mark_names)
+        mark_name_mapping: dict[str, list[Mark]] = {}
+        for mark in task.markers:
+            mark_name_mapping.setdefault(mark.name, []).append(mark)
+        return cls(mark_name_mapping)
 
-    def __call__(self, name: str) -> bool:
-        return name in self.own_mark_names
+    def __call__(self, name: str, /, **kwargs: str | int | bool | None) -> bool:
+        for mark in self.own_mark_name_mapping.get(name, []):
+            if all(
+                mark.kwargs.get(key, _NOT_SET) == value for key, value in kwargs.items()
+            ):
+                return True
+        return False
 
 
 def select_by_mark(session: Session, dag: DAG) -> set[str] | None:

--- a/src/_pytask/mark/expression.py
+++ b/src/_pytask/mark/expression.py
@@ -2,22 +2,22 @@ r"""Evaluate match expressions, as used by `-k` and `-m`.
 
 The grammar is:
 
-+------------+--------------------------------------------+
-| expression | expr? EOF                                  |
-+------------+--------------------------------------------+
-| expr       | and_expr ('or' and_expr)*                  |
-+------------+--------------------------------------------+
-| and_expr   | not_expr ('and' not_expr)*                 |
-+------------+--------------------------------------------+
-| not_expr   | ``'not' not_expr | '(' expr ')' | ident``  |
-+------------+--------------------------------------------+
-| ident      | ``(\w|:|\+|-|\.|\[|\]|\\)+``               |
-+------------+--------------------------------------------+
+expression: expr? EOF
+expr:       and_expr ('or' and_expr)*
+and_expr:   not_expr ('and' not_expr)*
+not_expr:   'not' not_expr | '(' expr ')' | ident kwargs?
+
+ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
+kwargs:     ('(' name '=' value (', ' name '=' value)* ')')
+name:       a valid identifier that is not a reserved keyword
+value:      unescaped string literal | (-)?[0-9]+ | 'False' | 'True' | 'None'
 
 The semantics are:
 
 - Empty expression evaluates to False.
-- ident evaluates to True of False according to a provided matcher function.
+- ident evaluates to True or False according to a provided matcher function.
+- ident with keyword arguments evaluates to True or False according to a provided
+  matcher function.
 - or/and/not evaluate according to the usual boolean semantics.
 
 This module is adapted from pytest's ``_pytest.mark.expression`` module:
@@ -29,20 +29,21 @@ from __future__ import annotations
 
 import ast
 import enum
+import keyword
 import re
-from collections.abc import Callable
 from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Protocol
 
 if TYPE_CHECKING:
     import types
     from typing import NoReturn
 
 
-__all__ = ["Expression"]
+__all__ = ["Expression", "ExpressionMatcher"]
 
 
 FILE_NAME = "<pytask match expression>"
@@ -56,6 +57,9 @@ class TokenType(enum.Enum):
     NOT = "not"
     IDENT = "identifier"
     EOF = "end of input"
+    EQUAL = "="
+    STRING = "string literal"
+    COMMA = ","
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +78,7 @@ class Scanner:
         self.tokens = self.lex(input_)
         self.current = next(self.tokens)
 
-    def lex(self, input_: str) -> Iterator[Token]:
+    def lex(self, input_: str) -> Iterator[Token]:  # noqa: C901, PLR0912
         pos = 0
         while pos < len(input_):
             if input_[pos] in (" ", "\t"):
@@ -85,6 +89,29 @@ class Scanner:
             elif input_[pos] == ")":
                 yield Token(TokenType.RPAREN, ")", pos)
                 pos += 1
+            elif input_[pos] == "=":
+                yield Token(TokenType.EQUAL, "=", pos)
+                pos += 1
+            elif input_[pos] == ",":
+                yield Token(TokenType.COMMA, ",", pos)
+                pos += 1
+            elif (quote_char := input_[pos]) in ("'", '"'):
+                end_quote_pos = input_.find(quote_char, pos + 1)
+                if end_quote_pos == -1:
+                    msg = f'closing quote "{quote_char}" is missing'
+                    raise SyntaxError(
+                        msg,
+                        (FILE_NAME, 1, pos + 1, input_),
+                    )
+                value = input_[pos : end_quote_pos + 1]
+                if (backslash_pos := value.find("\\")) != -1:
+                    msg = r'escaping with "\" not supported in marker expression'
+                    raise SyntaxError(
+                        msg,
+                        (FILE_NAME, 1, pos + backslash_pos + 1, input_),
+                    )
+                yield Token(TokenType.STRING, value, pos)
+                pos += len(value)
             else:
                 match = re.match(r"(:?\w|:|\+|-|\.|\[|\]|/|\\)+", input_[pos:])
                 if match:
@@ -168,19 +195,95 @@ def not_expr(s: Scanner) -> ast.expr:
     ident = s.accept(TokenType.IDENT)
     if ident:
         s.idents.add(ident.value)
-        return ast.Name(IDENT_PREFIX + ident.value, ast.Load())
+        name = ast.Name(IDENT_PREFIX + ident.value, ast.Load())
+        if s.accept(TokenType.LPAREN):
+            ret = ast.Call(func=name, args=[], keywords=all_kwargs(s))
+            s.accept(TokenType.RPAREN, reject=True)
+        else:
+            ret = name
+        return ret
     s.reject((TokenType.NOT, TokenType.LPAREN, TokenType.IDENT))
     return None  # ty: ignore[invalid-return-type]  # Unreachable: reject() raises
 
 
-class MatcherAdapter(Mapping[str, bool]):
+BUILTIN_MATCHERS = {"True": True, "False": False, "None": None}
+
+
+def single_kwarg(s: Scanner) -> ast.keyword:
+    """Parse one keyword argument."""
+    keyword_name = s.accept(TokenType.IDENT, reject=True)
+    assert keyword_name is not None
+    if not keyword_name.value.isidentifier():
+        msg = f"not a valid python identifier {keyword_name.value}"
+        raise SyntaxError(
+            msg,
+            (FILE_NAME, 1, keyword_name.pos + 1, s.input),
+        )
+    if keyword.iskeyword(keyword_name.value):
+        msg = f"unexpected reserved python keyword `{keyword_name.value}`"
+        raise SyntaxError(
+            msg,
+            (FILE_NAME, 1, keyword_name.pos + 1, s.input),
+        )
+    s.accept(TokenType.EQUAL, reject=True)
+
+    if value_token := s.accept(TokenType.STRING):
+        value: str | int | bool | None = value_token.value[1:-1]
+    else:
+        value_token = s.accept(TokenType.IDENT, reject=True)
+        assert value_token is not None
+        if (number := value_token.value).isdigit() or (
+            number.startswith("-") and number[1:].isdigit()
+        ):
+            value = int(number)
+        elif value_token.value in BUILTIN_MATCHERS:
+            value = BUILTIN_MATCHERS[value_token.value]
+        else:
+            msg = f'unexpected character/s "{value_token.value}"'
+            raise SyntaxError(
+                msg,
+                (FILE_NAME, 1, value_token.pos + 1, s.input),
+            )
+
+    return ast.keyword(keyword_name.value, ast.Constant(value))
+
+
+def all_kwargs(s: Scanner) -> list[ast.keyword]:
+    """Parse all keyword arguments."""
+    kwargs = [single_kwarg(s)]
+    while s.accept(TokenType.COMMA):
+        kwargs.append(single_kwarg(s))
+    return kwargs
+
+
+class ExpressionMatcher(Protocol):
+    """Match an identifier and optional keyword arguments."""
+
+    def __call__(self, name: str, /, **kwargs: str | int | bool | None) -> bool: ...
+
+
+@dataclass
+class MatcherNameAdapter:
+    """Adapt one matcher name to boolean and callable expression forms."""
+
+    matcher: ExpressionMatcher
+    name: str
+
+    def __bool__(self) -> bool:
+        return self.matcher(self.name)
+
+    def __call__(self, **kwargs: str | int | bool | None) -> bool:
+        return self.matcher(self.name, **kwargs)
+
+
+class MatcherAdapter(Mapping[str, MatcherNameAdapter]):
     """Adapts a matcher function to a locals mapping as required by eval()."""
 
-    def __init__(self, matcher: Callable[[str], bool]) -> None:
+    def __init__(self, matcher: ExpressionMatcher) -> None:
         self.matcher = matcher
 
-    def __getitem__(self, key: str) -> bool:
-        return self.matcher(key[len(IDENT_PREFIX) :])
+    def __getitem__(self, key: str) -> MatcherNameAdapter:
+        return MatcherNameAdapter(self.matcher, key[len(IDENT_PREFIX) :])
 
     def __iter__(self) -> Iterator[str]:  # pragma: no cover
         raise NotImplementedError
@@ -196,11 +299,17 @@ class Expression:
 
     """
 
-    __slots__ = ("_idents", "code")
+    __slots__ = ("_has_keyword_arguments", "_idents", "code")
 
-    def __init__(self, code: types.CodeType, idents: frozenset[str]) -> None:
+    def __init__(
+        self,
+        code: types.CodeType,
+        idents: frozenset[str],
+        has_keyword_arguments: bool,
+    ) -> None:
         self.code = code
         self._idents = idents
+        self._has_keyword_arguments = has_keyword_arguments
 
     @classmethod
     def compile_(cls, input_: str) -> Expression:
@@ -218,13 +327,20 @@ class Expression:
             filename="<pytask match expression>",
             mode="eval",
         )
-        return cls(code, idents)
+        has_keyword_arguments = any(
+            isinstance(node, ast.Call) for node in ast.walk(astexpr)
+        )
+        return cls(code, idents, has_keyword_arguments)
 
     def idents(self) -> frozenset[str]:
         """Return all identifiers which appear in the expression."""
         return self._idents
 
-    def evaluate(self, matcher: Callable[[str], bool]) -> bool:
+    def has_keyword_arguments(self) -> bool:
+        """Return whether the expression contains marker keyword arguments."""
+        return self._has_keyword_arguments
+
+    def evaluate(self, matcher: ExpressionMatcher) -> bool:
         """Evaluate the match expression.
 
         Parameters
@@ -239,7 +355,8 @@ class Expression:
             Whether the expression matches or not.
 
         """
-        ret: bool = eval(  # noqa: S307
-            self.code, {"__builtins__": {}}, MatcherAdapter(matcher)
+        return bool(
+            eval(  # noqa: S307
+                self.code, {"__builtins__": {}}, MatcherAdapter(matcher)
+            )
         )
-        return ret

--- a/tests/test_lock_command.py
+++ b/tests/test_lock_command.py
@@ -55,7 +55,7 @@ def _write_marked_chain_project(tmp_path):
             import pytask
 
 
-            @pytask.mark.try_first
+            @pytask.mark.try_first(priority=1)
             def task_downstream(depends_on=Path("up.txt"), produces=Path("down.txt")):
                 produces.write_text(depends_on.read_text() + "down")
             """
@@ -271,7 +271,7 @@ def test_lock_accept_uses_intersection_of_keyword_and_marker_selection(
             "-k",
             "downstream",
             "-m",
-            "try_first",
+            "try_first(priority=1)",
             "--yes",
             tmp_path.as_posix(),
         ],
@@ -286,6 +286,25 @@ def test_lock_accept_uses_intersection_of_keyword_and_marker_selection(
         _task_state_by_suffix(tmp_path, "task_downstream.py::task_downstream")
         != before_downstream
     )
+
+
+def test_lock_keyword_selection_rejects_call_parameters(runner, tmp_path):
+    _write_chain_project(tmp_path)
+
+    result = runner.invoke(
+        cli,
+        [
+            "lock",
+            "accept",
+            "-k",
+            "downstream(value=1)",
+            "--yes",
+            tmp_path.as_posix(),
+        ],
+    )
+
+    assert result.exit_code == ExitCode.DAG_FAILED
+    assert "Keyword expressions do not support call parameters." in result.output
 
 
 def test_lock_accept_no_matching_selection_is_a_no_op(runner, tmp_path):

--- a/tests/test_mark.py
+++ b/tests/test_mark.py
@@ -112,6 +112,67 @@ def test_mark_option(tmp_path, expr: str, expected_passed: str) -> None:
     assert set(tasks_that_run) == set(expected_passed)
 
 
+@pytest.mark.filterwarnings("ignore:Unknown pytask.mark.backend")
+@pytest.mark.parametrize(
+    ("expr", "expected_passed"),
+    [
+        ("backend", ["task_one", "task_two", "task_three"]),
+        ('backend(name="duckdb")', ["task_one", "task_three"]),
+        ('backend(name="duckdb", version=2)', ["task_one"]),
+        ("backend(active=False)", ["task_two"]),
+        ("backend(optional=None)", ["task_one"]),
+        ("backend(version=-1)", ["task_two"]),
+        ('backend(name="missing")', []),
+        (
+            'backend(name="duckdb") and not backend(version=1)',
+            ["task_one"],
+        ),
+    ],
+)
+def test_mark_option_with_keyword_arguments(
+    tmp_path, expr: str, expected_passed: list[str]
+) -> None:
+    tmp_path.joinpath("task_module.py").write_text(
+        textwrap.dedent(
+            """
+            import pytask
+
+            @pytask.mark.backend(
+                name="duckdb", version=2, active=True, optional=None
+            )
+            def task_one(): ...
+
+            @pytask.mark.backend(name="pandas", version=-1, active=False)
+            def task_two(): ...
+
+            @pytask.mark.backend(name="sqlite", version=1)
+            @pytask.mark.backend(name="duckdb", version=1)
+            def task_three(): ...
+            """
+        )
+    )
+
+    session = build(paths=tmp_path, marker_expression=expr)
+
+    tasks_that_run = [
+        report.task.name.rsplit("::")[1]
+        for report in session.execution_reports
+        if not report.exc_info
+    ]
+    assert set(tasks_that_run) == set(expected_passed)
+
+
+def test_keyword_option_rejects_call_parameters(tmp_path, capsys) -> None:
+    tmp_path.joinpath("task_module.py").write_text("def task_example(): ...")
+
+    session = build(paths=tmp_path, expression="task_example(value=1)")
+
+    assert session.exit_code == ExitCode.DAG_FAILED
+    assert (
+        "Keyword expressions do not support call parameters." in capsys.readouterr().out
+    )
+
+
 @pytest.mark.parametrize(
     ("expr", "expected_passed"),
     [
@@ -363,6 +424,7 @@ def test_error_with_unknown_marker_and_strict(runner, tmp_path):
         ("registered", True, ExitCode.OK),
         ("unknown", False, ExitCode.OK),
         ("unknown", True, ExitCode.DAG_FAILED),
+        ("unknown(value=1)", True, ExitCode.DAG_FAILED),
     ],
 )
 def test_strict_markers_validate_marker_expression(
@@ -392,7 +454,7 @@ def test_strict_markers_validate_marker_expression(
     result = runner.invoke(cli, args)
 
     assert result.exit_code == expected_exit_code
-    if strict_markers and marker_expression == "unknown":
+    if strict_markers and marker_expression.startswith("unknown"):
         assert "Unknown marker(s) in '-m' expression: unknown" in result.output
 
 

--- a/tests/test_mark_expression.py
+++ b/tests/test_mark_expression.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
+from typing import cast
 
 import pytest
 
+from _pytask.mark import MarkMatcher
 from _pytask.mark.expression import Expression
+from _pytask.mark.expression import ExpressionMatcher
+from _pytask.mark.structures import Mark
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def evaluate(input_: str, matcher: Callable[[str], bool]) -> bool:
-    return Expression.compile_(input_).evaluate(matcher)
+def evaluate(input_: str, matcher: Callable[..., bool]) -> bool:
+    return Expression.compile_(input_).evaluate(cast("ExpressionMatcher", matcher))
 
 
 def test_empty_is_false() -> None:
@@ -27,6 +32,7 @@ def test_empty_is_false() -> None:
         ("", frozenset()),
         ("first", frozenset({"first"})),
         ("first and (second or first)", frozenset({"first", "second"})),
+        ("mark(a=1)", frozenset({"mark"})),
     ],
 )
 def test_expression_exposes_identifiers(expr: str, expected: frozenset[str]) -> None:
@@ -213,3 +219,139 @@ def test_backslash_not_treated_specially() -> None:
     assert not evaluate(r"foo", matcher)
     with pytest.raises(SyntaxError):
         evaluate("\nfoo\n", matcher)
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_error_msg"),
+    [
+        ("mark()", "expected identifier; got right parenthesis"),
+        ("mark(True=False)", "unexpected reserved python keyword `True`"),
+        ("mark(def=False)", "unexpected reserved python keyword `def`"),
+        ("mark(1)", "not a valid python identifier 1"),
+        ("mark(class=True)", "unexpected reserved python keyword `class`"),
+        ("mark(if=False)", "unexpected reserved python keyword `if`"),
+        ("mark(else=False)", "unexpected reserved python keyword `else`"),
+        ("mark(valid=False, def=1)", "unexpected reserved python keyword `def`"),
+        ("mark(var:=False", "not a valid python identifier var:"),
+        ("mark(1=2)", "not a valid python identifier 1"),
+        ("mark(/=2)", "not a valid python identifier /"),
+        ("mark(var==", "expected identifier; got ="),
+        ("mark(var)", "expected =; got right parenthesis"),
+        ("mark(var=none)", 'unexpected character/s "none"'),
+        ("mark(var=1.1)", 'unexpected character/s "1.1"'),
+        ("mark(var=')", """closing quote "'" is missing"""),
+        ('mark(var=")', 'closing quote """ is missing'),
+        ("""mark(var="')""", 'closing quote """ is missing'),
+        ("""mark(var='")""", """closing quote "'" is missing"""),
+        (
+            r"mark(var='\hugo')",
+            r'escaping with "\\" not supported in marker expression',
+        ),
+        ("mark(empty_list=[])", r'unexpected character/s "\[\]"'),
+        ("'str'", "expected not OR left parenthesis OR identifier; got string literal"),
+    ],
+)
+def test_invalid_kwarg_name_or_value(
+    expr: str, expected_error_msg: str, mark_matcher: MarkMatcher
+) -> None:
+    with pytest.raises(SyntaxError, match=expected_error_msg):
+        assert evaluate(expr, mark_matcher)
+
+
+@pytest.fixture(scope="session")
+def mark_matcher() -> MarkMatcher:
+    markers = [
+        Mark("number_mark", (), {"a": 1, "b": 2, "c": 3, "d": 999_999}),
+        Mark("builtin_matchers_mark", (), {"x": True, "y": False, "z": None}),
+        Mark(
+            "str_mark",
+            (),
+            {
+                "m": "M",
+                "space": "with space",
+                "empty": "",
+                "aaאבגדcc": "aaאבגדcc",
+                "אבגד": "אבגד",
+            },
+        ),
+    ]
+    mark_name_mapping: defaultdict[str, list[Mark]] = defaultdict(list)
+    for marker in markers:
+        mark_name_mapping[marker.name].append(marker)
+
+    return MarkMatcher(mark_name_mapping)
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("number_mark(a=1)", True),
+        ("number_mark(b=2)", True),
+        ("number_mark(a=1,b=2)", True),
+        ("number_mark(a=1,     b=2)", True),
+        ("number_mark(d=999999)", True),
+        ("number_mark(a   =   1,b= 2,     c = 3)", True),
+        ("number_mark(a=6)", False),
+        ("number_mark(b=6)", False),
+        ("number_mark(a=1,b=6)", False),
+        ("number_mark(a=6,b=2)", False),
+        ("number_mark(a   =   1,b= 2,     c = 6)", False),
+        ("number_mark(a='1')", False),
+    ],
+)
+def test_keyword_expressions_with_numbers(
+    expr: str, expected: bool, mark_matcher: MarkMatcher
+) -> None:
+    assert evaluate(expr, mark_matcher) is expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("builtin_matchers_mark(x=True)", True),
+        ("builtin_matchers_mark(x=False)", False),
+        ("builtin_matchers_mark(y=True)", False),
+        ("builtin_matchers_mark(y=False)", True),
+        ("builtin_matchers_mark(z=None)", True),
+        ("builtin_matchers_mark(z=False)", False),
+        ("builtin_matchers_mark(z=True)", False),
+        ("builtin_matchers_mark(z=0)", False),
+        ("builtin_matchers_mark(z=1)", False),
+    ],
+)
+def test_builtin_matchers_keyword_expressions(
+    expr: str, expected: bool, mark_matcher: MarkMatcher
+) -> None:
+    assert evaluate(expr, mark_matcher) is expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("str_mark(m='M')", True),
+        ('str_mark(m="M")', True),
+        ("str_mark(aaאבגדcc='aaאבגדcc')", True),
+        ("str_mark(אבגד='אבגד')", True),
+        ("str_mark(space='with space')", True),
+        ("str_mark(empty='')", True),
+        ('str_mark(empty="")', True),
+        ("str_mark(m='wrong')", False),
+        ("str_mark(aaאבגדcc='wrong')", False),
+        ("str_mark(אבגד='wrong')", False),
+        ("str_mark(m='')", False),
+        ('str_mark(m="")', False),
+    ],
+)
+def test_str_keyword_expressions(
+    expr: str, expected: bool, mark_matcher: MarkMatcher
+) -> None:
+    assert evaluate(expr, mark_matcher) is expected
+
+
+def test_backslash_in_identifier_with_string_literal() -> None:
+    def matcher(name: str, /, **_kwargs: str | int | bool | None) -> bool:
+        return {r"\nfoo\n", r"test\case", "mark"}.__contains__(name)
+
+    assert evaluate(r'\nfoo\n and mark(x="y")', matcher)
+    assert evaluate(r'mark(x="y") and \nfoo\n', matcher)
+    assert evaluate(r'test\case and mark(x="y")', matcher)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -684,6 +684,23 @@ def test_raise_error_for_wrong_after_expression(runner, tmp_path):
     assert "Wrong expression passed to 'after'" in result.output
 
 
+def test_after_expression_rejects_call_parameters(runner, tmp_path):
+    source = """
+    from pytask import task
+
+    def task_first(): ...
+
+    @task(after="task_first(value=1)")
+    def task_second(): ...
+    """
+    tmp_path.joinpath("task_example.py").write_text(textwrap.dedent(source))
+
+    result = runner.invoke(cli, [tmp_path.as_posix()])
+
+    assert result.exit_code == ExitCode.DAG_FAILED
+    assert "Keyword expressions do not support call parameters." in result.output
+
+
 def test_raise_error_with_builtin_function_as_task(runner, tmp_path):
     source = """
     from pytask import task


### PR DESCRIPTION
## Summary

- support keyword arguments in marker expressions passed to `-m`
- match marker metadata in build and lock task selection while keeping `-k` and `after=` semantics unchanged
- reject escaped marker-expression strings without misreading backslashes elsewhere in the expression
- document marker metadata selection and its supported values

Adapted from [pytest commit 15c33fbaa](https://github.com/pytest-dev/pytest/commit/15c33fbaa3e8569af0efa7532ac59f5f0fb3ba4a) and [pytest #14475](https://github.com/pytest-dev/pytest/pull/14475).

## Tests

- `uv run --group test pytest tests/test_mark_expression.py tests/test_mark.py tests/test_task.py tests/test_lock_command.py -q`
- `just typing`
- targeted pre-commit checks
- `just docs`